### PR TITLE
[FEATURE] Feature/Link Pull Request To Issue

### DIFF
--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -18,9 +18,17 @@
           "type": "boolean",
           "description": "Indicates to continue a previously failed build attempt"
         },
+        "DeleteLocalOnSuccess": {
+          "type": "boolean",
+          "description": "Should the local branch be deleted after the pull request was created successfully ?"
+        },
         "Description": {
           "type": "string",
           "description": "Description of the pull request"
+        },
+        "Draft": {
+          "type": "boolean",
+          "description": "Indicates to open the pull request as 'draft'"
         },
         "GitHubToken": {
           "type": "string",
@@ -55,6 +63,13 @@
         "IgnoreFailedSources": {
           "type": "boolean",
           "description": "Ignore unreachable sources during Restore"
+        },
+        "Issues": {
+          "type": "array",
+          "description": "Issues that will be closed once the pull request is merged",
+          "items": {
+            "type": "string"
+          }
         },
         "Major": {
           "type": "boolean",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Moved `ICreateGitHubRelease` to `Candoumbe.Pipelines.Components.GitHub` namespace
 
 ### New features
-
+- Added `IPullRequest.Issues` parameter which allows to specify issues a pull request fixes ([#9](https://github.com/candoumbe/pipelines/issues/9))
 - Added execution of `IPublish.Publish` target on `integration` workflow
 - Added `IHaveReport` component that can be used by pipelines that output reports of any kind (code coverage, performance tests, ...)
 - Added `IUnitTest.UnitTestsResultsDirectory` which defines where to output unit test result files
@@ -24,6 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `IBenchmark.BenchmarkTestResultsDirectory` which defines where to output benchmarks test result files
 - Added `IPullRequest` component which extends `IGitFlow` and create pull requests instead or merging back to `develop` (respectiveley `main`) when finishing a feature / coldfix (resp. release / hotfix) branch.
 - Added `IHaveGitHubRepository` which extends `IHaveGitRepository` and specific properties related to GitHub repositories.
+- Promoted `IPullRequest.DeleteLocalOnSuccess` as parameter
+- Promoted `IPullRequest.Draft` as parameter
 
 ### Fixes
 


### PR DESCRIPTION
### Breaking changes
• Renamed IBenchmarks to IBenchmark
• Renamed IMutationTests to IMutationTest
• Made IGitFlow.FinishFeature async
• Made IGitFlow.FinishReleaseOrHotfix async
• Made IGitFlow.FinishColdfix async
• Moved GitHubPublishConfiguration to Candoumbe.Pipelines.Components.GitHub namespace
• Moved ICreateGitHubRelease to Candoumbe.Pipelines.Components.GitHub namespace
### New features
• Added IPullRequest.Issues parameter which allows to specify issues a pull request fixes ([#9](https://github.com/candoumbe/pipelines/issues/9))
• Added execution of IPublish.Publish target on integration workflow
• Added IHaveReport component that can be used by pipelines that output reports of any kind (code coverage%2C performance tests%2C ...)
• Added IUnitTest.UnitTestsResultsDirectory which defines where to output unit test result files
• Added IMutationTest.MutationTestResultsDirectory which defines where to output mutation test result files
• Added IBenchmark.BenchmarkTestResultsDirectory which defines where to output benchmarks test result files
• Added IPullRequest component which extends IGitFlow and create pull requests instead or merging back to develop (respectiveley main) when finishing a feature / coldfix (resp. release / hotfix) branch.
• Added IHaveGitHubRepository which extends IHaveGitRepository and specific properties related to GitHub repositories.
• Promoted IPullRequest.DeleteLocalOnSuccess as parameter
• Promoted IPullRequest.Draft as parameter
### Fixes
• Fixed directory path used by IUnitTest target to output unit tests results.
• Fixed argument format used to define reporters used when running mutation tests.

Full changelog at https://github.com/candoumbe/Pipelines/blob/feature/link-pull-request-to-issue/CHANGELOG.md


Resolves #9 