### PR TITLE
[COLDFIX] Navigation To Pull Request After Its Creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `IHaveGitHubRepository` which extends `IHaveGitRepository` and specific properties related to GitHub repositories.
 - Promoted `IPullRequest.DeleteLocalOnSuccess` as parameter
 - Promoted `IPullRequest.Draft` as parameter
+- Newly created pull request open in the default browser after creation ([#10](https://github.com/candoumbe/pipelines/issues/10))
 
 ### Fixes
 


### PR DESCRIPTION
### Breaking changes
• Renamed IBenchmarks to IBenchmark
• Renamed IMutationTests to IMutationTest
• Made IGitFlow.FinishFeature async
• Made IGitFlow.FinishReleaseOrHotfix async
• Made IGitFlow.FinishColdfix async
• Moved GitHubPublishConfiguration to Candoumbe.Pipelines.Components.GitHub namespace
• Moved ICreateGitHubRelease to Candoumbe.Pipelines.Components.GitHub namespace
### New features
• Added IPullRequest.Issues parameter which allows to specify issues a pull request fixes ([#9](https://github.com/candoumbe/pipelines/issues/9))
• Added execution of IPublish.Publish target on integration workflow
• Added IHaveReport component that can be used by pipelines that output reports of any kind (code coverage%2C performance tests%2C ...)
• Added IUnitTest.UnitTestsResultsDirectory which defines where to output unit test result files
• Added IMutationTest.MutationTestResultsDirectory which defines where to output mutation test result files
• Added IBenchmark.BenchmarkTestResultsDirectory which defines where to output benchmarks test result files
• Added IPullRequest component which extends IGitFlow and create pull requests instead or merging back to develop (respectiveley main) when finishing a feature / coldfix (resp. release / hotfix) branch.
• Added IHaveGitHubRepository which extends IHaveGitRepository and specific properties related to GitHub repositories.
• Promoted IPullRequest.DeleteLocalOnSuccess as parameter
• Promoted IPullRequest.Draft as parameter
• Newly created pull request open in the default browser after creation ([#10](https://github.com/candoumbe/pipelines/issues/10))
### Fixes
• Fixed directory path used by IUnitTest target to output unit tests results.
• Fixed argument format used to define reporters used when running mutation tests.

Full changelog at https://github.com/candoumbe/Pipelines/blob/coldfix/navigation-to-pull-request-after-its-creation/CHANGELOG.md

Resolves #11 
