### PR TITLE
[COLDFIX] Pack Should Not Depends On Mutation Tests Being Run

### DIFF
--- a/src/Candoumbe.Pipelines/Components/IPack.cs
+++ b/src/Candoumbe.Pipelines/Components/IPack.cs
@@ -32,7 +32,6 @@ public interface IPack : IHaveArtifacts, ICompile
     /// </summary>
     public Target Pack => _ => _
         .TryDependsOn<IUnitTest>(x => x.UnitTests)
-        .TryDependsOn<IMutationTest>(x => x.MutationTests)
         .DependsOn(Compile)
         .Consumes(Compile)
         .Produces(PackagesDirectory / "*.nupkg")


### PR DESCRIPTION
### Breaking changes
• Renamed IBenchmarks to IBenchmark
• Renamed IMutationTests to IMutationTest
• Moved IGitFlow to Candoumbe.Pipelines.Components.Workflows namespace
• Made IGitFlow.FinishFeature async
• Made IGitFlow.FinishReleaseOrHotfix async
• Made IGitFlow.FinishColdfix async
• Moved GitHubPublishConfiguration to Candoumbe.Pipelines.Components.GitHub namespace
• Moved ICreateGitHubRelease to Candoumbe.Pipelines.Components.GitHub namespace
### New features
• Added IGithubFlowWithPullRequest
• Added IGitFlowWithPullRequest
• Added IPullRequest component which extends IWorkflow and create pull requests instead or merging back to develop (respectiveley main) when finishing a feature / coldfix (resp. release / hotfix) branch.
• Added IGitHubFlow ([#15](https://github.com/candoumbe/pipelines/issues/15))
• Added IPullRequest.Issues parameter which allows to specify issues a pull request fixes ([#9](https://github.com/candoumbe/pipelines/issues/9))
• Added execution of IPublish.Publish target on integration workflow
• Added IHaveReport component that can be used by pipelines that output reports of any kind (code coverage%2C performance tests%2C ...)
• Added IUnitTest.UnitTestsResultsDirectory which defines where to output unit test result files
• Added IUnitTest.ProjectUnitTestSettings to customize/override the unit tests settings.
• Added IMutationTest.MutationTestResultsDirectory which defines where to output mutation test result files
• Added IBenchmark.BenchmarkTestResultsDirectory which defines where to output benchmarks test result files
• Added IHaveGitHubRepository which extends IHaveGitRepository and specific properties related to GitHub repositories.
• Promoted IPullRequest.DeleteLocalOnSuccess as parameter
• Promoted IPullRequest.Draft as parameter
• Newly created pull request open in the default browser after creation ([#10](https://github.com/candoumbe/pipelines/issues/10))
### Fixes
• Fixed directory path used by IUnitTest target to output unit tests results.
• Fixed argument format used to define reporters used when running mutation tests.

Full changelog at https://github.com/candoumbe/Pipelines/blob/coldfix/pack-should-not-depends-on-mutation-tests-being-run/CHANGELOG.md

Resolves #24