### PR TITLE
[COLDFIX] Configuration Should Behave Like An Enum

### DIFF
--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -12,7 +12,10 @@
         },
         "Configuration": {
           "type": "string",
-          "enum": []
+          "enum": [
+            "Debug",
+            "Release"
+          ]
         },
         "Continue": {
           "type": "boolean",

--- a/build/Candoumbe.Pipelines.Build.csproj
+++ b/build/Candoumbe.Pipelines.Build.csproj
@@ -60,37 +60,4 @@
     <PackageReference Include="Candoumbe.Miscutilities" Version="0.10.0" />
     <PackageDownload Include="GitVersion.Tool" Version="[5.10.3]" />
   </ItemGroup>
-
-  <ItemGroup>
-    <None Remove="..\.nuke\temp\**" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Remove="..\.nuke\temp\build.log" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Remove="..\.nuke\temp\build.2022-10-22_17-17-40.log" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Remove="..\.nuke\temp\build.2022-10-22_17-02-27.log" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Remove="..\.nuke\temp\build.2022-10-22_16-48-01.log" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Remove="..\.nuke\temp\build.2022-10-22_15-18-51.log" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Remove="..\.nuke\temp\build.2022-10-22_15-07-14.log" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Remove="..\.nuke\temp\build.2022-10-22_14-59-01.log" />
-  </ItemGroup>
-
 </Project>

--- a/build/Pipeline.cs
+++ b/build/Pipeline.cs
@@ -73,7 +73,7 @@ public class Pipeline : NukeBuild,
     IHaveSecret
 {
     ///<inheritdoc/>
-    IEnumerable<AbsolutePath> IClean.DirectoriesToDelete => RootDirectory.GlobDirectories("**/bin", "**/obj");
+    IEnumerable<AbsolutePath> IClean.DirectoriesToDelete => this.Get<IHaveSourceDirectory>().SourceDirectory.GlobDirectories("**/bin", "**/obj");
 
     ///<inheritdoc/>
     IEnumerable<AbsolutePath> IClean.DirectoriesToEnsureExistance => new[]

--- a/src/Candoumbe.Pipelines/Candoumbe.Pipelines.csproj
+++ b/src/Candoumbe.Pipelines/Candoumbe.Pipelines.csproj
@@ -8,7 +8,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.DependencyValidation.Analyzers" Version="0.11.0" />
     <PackageReference Include="Nuke.Common" Version="6.2.1" />
   </ItemGroup>
 </Project>

--- a/src/Candoumbe.Pipelines/Components/Configuration.cs
+++ b/src/Candoumbe.Pipelines/Components/Configuration.cs
@@ -1,29 +1,18 @@
-﻿using JetBrains.Annotations;
-
-using Nuke.Common.Tooling;
-
-using System.ComponentModel;
-
-namespace Candoumbe.Pipelines.Components
+﻿namespace Candoumbe.Pipelines.Components
 {
     /// <summary>
-    /// Configuration that can be used throughout CI/CD pipelines
+    /// Configuration that can be used to compile an application
     /// </summary>
-    [PublicAPI]
-    [TypeConverter(typeof(TypeConverter<Configuration>))]
-    public class Configuration : Enumeration
+    public enum Configuration
     {
         /// <summary>
-        /// The "Debug" mode
+        /// Debug mode
         /// </summary>
-        public static Configuration Debug => new() { Value = nameof(Debug) };
+        Debug,
 
         /// <summary>
-        /// The "release" mode
+        /// Release mode
         /// </summary>
-        public static Configuration Release => new() { Value = nameof(Release) };
-
-        ///<inheritdoc/>
-        public static implicit operator string(Configuration configuration) => configuration.Value;
+        Release
     }
 }

--- a/src/Candoumbe.Pipelines/Components/IBenchmark.cs
+++ b/src/Candoumbe.Pipelines/Components/IBenchmark.cs
@@ -37,7 +37,7 @@ public interface IBenchmark : ICompile, IHaveArtifacts
         {
             BenchmarkProjects.ForEach(csproj =>
             {
-                DotNetRun(s => s.SetConfiguration(Configuration.Release)
+                DotNetRun(s => s.SetConfiguration(nameof(Configuration.Release))
                                 .SetProjectFile(csproj)
                                 .CombineWith(csproj.GetTargetFrameworks(),
                                              (setting, framework) => setting.SetFramework(framework))
@@ -50,7 +50,7 @@ public interface IBenchmark : ICompile, IHaveArtifacts
     /// Configures the way performance tests are run.
     /// </summary>
     public sealed Configure<DotNetRunSettings> BenchmarksSettingsBase => _ => _
-            .SetConfiguration(Configuration.Release)
+            .SetConfiguration(nameof(Configuration.Release))
             .SetProcessArgumentConfigurator(args => args.Add("-- --filter {0}", "*", customValue: true)
                                                         .Add("--artifacts {0}", BenchmarkResultDirectory)
                                                         .Add("--join"));

--- a/src/Candoumbe.Pipelines/Components/ICompile.cs
+++ b/src/Candoumbe.Pipelines/Components/ICompile.cs
@@ -42,7 +42,7 @@ public interface ICompile : IRestore, IHaveConfiguration
     public sealed Configure<DotNetBuildSettings> CompileSettingsBase => _ => _
                 .SetNoRestore(SucceededTargets.Contains(Restore) || SkippedTargets.Contains(Restore))
                 .SetProjectFile(Solution)
-                .SetConfiguration(Configuration)
+                .SetConfiguration(Configuration.ToString())
                 .SetContinuousIntegrationBuild(IsServerBuild)
                 .WhenNotNull(this as IHaveGitVersion,
                              (settings, gitVersion) => settings.SetAssemblyVersion(gitVersion.GitVersion.AssemblySemVer)

--- a/src/Candoumbe.Pipelines/Components/IHaveConfiguration.cs
+++ b/src/Candoumbe.Pipelines/Components/IHaveConfiguration.cs
@@ -14,6 +14,5 @@ public interface IHaveConfiguration : INukeBuild
     /// Configuration currently supported by the pipeline
     /// </summary>
     [Parameter]
-    public Configuration Configuration => TryGetValue(() => Configuration) ??
-                                                   (IsLocalBuild ? Configuration.Debug : Configuration.Release);
+    public Configuration Configuration => IsLocalBuild ? Configuration.Debug : Configuration.Release;
 }

--- a/src/Candoumbe.Pipelines/Components/IPack.cs
+++ b/src/Candoumbe.Pipelines/Components/IPack.cs
@@ -61,7 +61,7 @@ public interface IPack : IHaveArtifacts, ICompile
         .SetOutputDirectory(PackagesDirectory)
         .SetNoBuild(SucceededTargets.Contains(Compile) || SkippedTargets.Contains(Compile))
         .SetNoRestore(SucceededTargets.Contains(Restore) || SucceededTargets.Contains(Compile))
-        .SetConfiguration(Configuration)
+        .SetConfiguration(Configuration.ToString())
         .SetSymbolPackageFormat(DotNetSymbolPackageFormat.snupkg)
         .WhenNotNull(this as IHaveGitVersion,
                      (_, versioning) => _.SetAssemblyVersion(versioning.GitVersion.AssemblySemVer)

--- a/src/Candoumbe.Pipelines/Components/IUnitTest.cs
+++ b/src/Candoumbe.Pipelines/Components/IUnitTest.cs
@@ -65,7 +65,7 @@ type: AzurePipelinesTestResultsType.VSTest,
         });
 
     internal sealed Configure<DotNetTestSettings> UnitTestSettingsBase => _ => _
-        .SetConfiguration(Configuration)
+        .SetConfiguration(Configuration.ToString())
                 .ResetVerbosity()
                 .EnableCollectCoverage()
                 .EnableUseSourceLink()


### PR DESCRIPTION
### Breaking changes
• Renamed IBenchmarks to IBenchmark
• Renamed IMutationTests to IMutationTest
• Moved IGitFlow to Candoumbe.Pipelines.Components.Workflows namespace
• Made IGitFlow.FinishFeature async
• Made IGitFlow.FinishReleaseOrHotfix async
• Made IGitFlow.FinishColdfix async
• Moved GitHubPublishConfiguration to Candoumbe.Pipelines.Components.GitHub namespace
• Moved ICreateGitHubRelease to Candoumbe.Pipelines.Components.GitHub namespace
• Made IPublish.PublishConfigurations mandatory
### New features
• Added IGithubFlowWithPullRequest
• Added IGitFlowWithPullRequest
• Added IPullRequest component which extends IWorkflow and create pull requests instead or merging back to develop (respectiveley main) when finishing a feature / coldfix (resp. release / hotfix) branch.
• Added IGitHubFlow ([#15](https://github.com/candoumbe/pipelines/issues/15))
• Added IPullRequest.Issues parameter which allows to specify issues a pull request fixes ([#9](https://github.com/candoumbe/pipelines/issues/9))
• Added execution of IPublish.Publish target on integration workflow
• Added IHaveReport component that can be used by pipelines that output reports of any kind (code coverage%2C performance tests%2C ...)
• Added IUnitTest.UnitTestsResultsDirectory which defines where to output unit test result files
• Added IUnitTest.ProjectUnitTestSettings to customize/override the unit tests settings.
• Added IMutationTest.MutationTestResultsDirectory which defines where to output mutation test result files
• Added IBenchmark.BenchmarkTestResultsDirectory which defines where to output benchmarks test result files
• Added IHaveGitHubRepository which extends IHaveGitRepository and specific properties related to GitHub repositories.
• Promoted IPullRequest.DeleteLocalOnSuccess as parameter
• Promoted IPullRequest.Draft as parameter
• Newly created pull request open in the default browser after creation ([#10](https://github.com/candoumbe/pipelines/issues/10))
### Fixes
• Fixed directory path used by IUnitTest target to output unit tests results.
• Fixed argument format used to define reporters used when running mutation tests.

Full changelog at https://github.com/candoumbe/Pipelines/blob/coldfix/configuration-should-behave-like-an-enum/CHANGELOG.md

Resolves #33