### PR TITLE
[COLDFIX] Publish Does Not Define Mandatory Source Target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changes
 - No more pull request for finishing a hotfix/release branch when using IGitFlowPullRequest or IGithubFlowPullRequest.
 
+### Fixes
+- Missing `Source` parameter when running `IPublish.Publish` target ([#46](https://github.com/candoumbe/Pipelines))
+
 ## [0.2.0] / 2023-01-20
 ### Breaking changes
 - Renamed `IBenchmarks` to `IBenchmark`

--- a/src/Candoumbe.Pipelines/Components/IPublish.cs
+++ b/src/Candoumbe.Pipelines/Components/IPublish.cs
@@ -63,7 +63,8 @@ public interface IPublish : IPack
                                                              .Apply(PackagePublishSettings)
                                                              .CombineWith(PublishConfigurations,
                                                                           (setting, config) => setting.When(config.CanBeUsed(),
-                                                                                                              _ => _.SetApiKey(config.Key))
+                                                                                                              _ => _.SetApiKey(config.Key)
+                                                                                                                    .SetSource(config.Source.ToString()))
                                                                   ),
                                                   degreeOfParallelism: PushDegreeOfParallelism,
                                                   completeOnFailure: PushCompleteOnFailure);


### PR DESCRIPTION
### Changes
• No more pull request for finishing a hotfix/release branch when using IGitFlowPullRequest or IGithubFlowPullRequest.
### Fixes
• Missing Source parameter when running IPublish.Publish target ([#46](https://github.com/candoumbe/Pipelines))

Full changelog at https://github.com/candoumbe/Pipelines/blob/coldfix/publish-does-not-define-mandatory-source-target/CHANGELOG.md