### PR TITLE
[FEATURE] Deactivate Publishing Packages From Develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,24 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixes
+### 🔧 Fixes
 - Added `EnableNoSymbols` switch on `IPublish.Publish` target
 - No more pull request for finishing a hotfix/release branch when using IGitFlowPullRequest or IGithubFlowPullRequest.
 - Missing `Source` parameter when running `IPublish.Publish` target ([#46](https://github.com/candoumbe/Pipelines)).
 
 ## [0.2.0] / 2023-01-20
-### Breaking changes
-- Renamed `IBenchmarks` to `IBenchmark`
-- Renamed `IMutationTests` to `IMutationTest`
-- Moved `IGitFlow` to `Candoumbe.Pipelines.Components.Workflows` namespace
-- Made `IGitFlow.FinishFeature` async
-- Made `IGitFlow.FinishReleaseOrHotfix` async
-- Made `IGitFlow.FinishColdfix` async
-- Moved `GitHubPublishConfiguration` to `Candoumbe.Pipelines.Components.GitHub` namespace
-- Moved `ICreateGitHubRelease` to `Candoumbe.Pipelines.Components.GitHub` namespace
-- Made `IPublish.PublishConfigurations` mandatory
-
-### New features
+### 🚀 New features
 - Added `IGithubFlowWithPullRequest`
 - Added `IGitFlowWithPullRequest`
 - Added `IPullRequest` component which extends `IWorkflow` and create pull requests instead or merging back to `develop` (respectiveley `main`) when finishing a feature / coldfix (resp. release / hotfix) branch.
@@ -42,7 +31,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Newly created pull request open in the default browser after creation ([#10](https://github.com/candoumbe/pipelines/issues/10))
 - Changed `IWorkflow.Changelog` target to autocommit changes when running on a build server ([#39](https://github.com/candoumbe/pipelines/issues/39))
 
-### Fixes
+### ⚠️ Breaking changes
+- Renamed `IBenchmarks` to `IBenchmark`
+- Renamed `IMutationTests` to `IMutationTest`
+- Moved `IGitFlow` to `Candoumbe.Pipelines.Components.Workflows` namespace
+- Made `IGitFlow.FinishFeature` async
+- Made `IGitFlow.FinishReleaseOrHotfix` async
+- Made `IGitFlow.FinishColdfix` async
+- Moved `GitHubPublishConfiguration` to `Candoumbe.Pipelines.Components.GitHub` namespace
+- Moved `ICreateGitHubRelease` to `Candoumbe.Pipelines.Components.GitHub` namespace
+- Made `IPublish.PublishConfigurations` mandatory
+
+### 🔧 Fixes
 - Fixed directory path used by `IUnitTest` target to output unit tests results.
 - Fixed argument format used to define reporters used when running mutation tests.
 - Fixed `SourceName` not displayed when running `IPublish.Publish` target

--- a/build/Pipeline.cs
+++ b/build/Pipeline.cs
@@ -58,7 +58,6 @@ using static Nuke.Common.Tools.Git.GitTasks;
             "LICENSE"
         })]
 [DotNetVerbosityMapping]
-[ShutdownDotNetAfterServerBuild]
 public class Pipeline : NukeBuild,
     IHaveSourceDirectory,
     IHaveSolution,

--- a/src/Candoumbe.Pipelines/Components/IPublish.cs
+++ b/src/Candoumbe.Pipelines/Components/IPublish.cs
@@ -35,8 +35,7 @@ public interface IPublish : IPack
         .WhenNotNull(this as IHaveGitRepository,
                      (_, repository) => _.Requires(() => GitHasCleanWorkingCopy())
                                          .OnlyWhenDynamic(() => repository.GitRepository.IsOnMainBranch()
-                                                                || repository.GitRepository.IsOnReleaseBranch()
-                                                                || repository.GitRepository.IsOnDevelopBranch()))
+                                                                || repository.GitRepository.IsOnReleaseBranch()))
         .Requires(() => Configuration.Equals(Configuration.Release))
         .Executes(() =>
         {


### PR DESCRIPTION
### 🔧 Fixes
• Added EnableNoSymbols switch on IPublish.Publish target
• No more pull request for finishing a hotfix/release branch when using IGitFlowPullRequest or IGithubFlowPullRequest.
• Missing Source parameter when running IPublish.Publish target ([#46](https://github.com/candoumbe/Pipelines)).

Full changelog at https://github.com/candoumbe/Pipelines/blob/feature/deactivate-publishing-packages-from-develop/CHANGELOG.md

Resolves #51