### PR TITLE
[FEATURE] Pulish Nupkg By Specifying Config Name

### DIFF
--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -12,7 +12,7 @@
         },
         "ConfigName": {
           "type": "string",
-          "description": "Which specific configuration to publish packages to"
+          "description": "Defines the name of the configuration to use to publish packages"
         },
         "Configuration": {
           "type": "string",

--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -10,6 +10,10 @@
           "type": "boolean",
           "description": "Indicates if any changes should be stashed automatically prior to switching branch (Default : true)"
         },
+        "ConfigName": {
+          "type": "string",
+          "description": "Which specific configuration to publish packages to"
+        },
         "Configuration": {
           "type": "string",
           "description": "Defines the configuratoin to use when building the application",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### 🚀 New features
 - Added `ConfigName` parameter to specify the name of the configuration to use when pushing nuget packages ([#37](https://github.com/candoumbe/Pipelines/issues/37)).
+- Changes requirements of `IPushNugetPackages.Publish` target to make it runnable locally
 
 ## [0.4.3] / 2023-07-10
 ### 🔧 Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### 🚀 New features
+- Added `ConfigName` parameter to specify the name of the configuration to use when pushing nuget packages ([#37](https://github.com/candoumbe/Pipelines/issues/37)).
 
 ## [0.4.3] / 2023-07-10
 ### 🔧 Fixes

--- a/README.md
+++ b/README.md
@@ -5,11 +5,166 @@
 [![GitHub raw issues](https://img.shields.io/github/issues-raw/candoumbe/pipelines)](https://github.com/candoumbe/pipelines/issues)
 [![Nuget](https://img.shields.io/nuget/vpre/candoumbe.pipelines)](https://nuget.org/packages/candoumbe.pipelines)
 
-A Stater development kit to script your CI/CD using [Nuke].
+A starter development kit to script your CI/CD using [Nuke].
 
+## Disclaimer
 
-## Credits
+This project adheres to [semantic versioning].
+
+Major version zero (0.y.z) is for initial development. **Anything MAY change at any time**.
+
+The public API SHOULD NOT be considered stable.
+
+## The problem
+
+Most of the time, to set up a CI/CD for your .NET project, you have two options :
+
+### **Going through your repository and use its embeded GUI to create the pipeline**
+
+This approach is nice and helpful to get started. But most of the time, the history of changes made to the pipeline
+is separated from the history of the code base.
+
+### **Writing a pipeline file of some sort**
+
+Most of the time in YAML, the file that describes the steps required to build a project are providers specific.
+So even though you can write YAML, knowning how to write an Azure DevOps pipeline does not really help when it comes to writing a pipeline for GitHub Actions.
+
+## The solution
+
+This project offers an opinionated way at writing pipelines by giving a set of components (more on that later) with the following benefits :
+
+1. no need to go your code management tool to set up your project CI/CD.
+2. no more YAML file : yeah YAML is great but the tooling around it is not great and the structure itself is error prone.
+3. it's just a C# that every team member can contribute to !
+4. it sits right with your source code so that each change to the pipeline is just a commit into your
+codebase.
+
+### Try it out
+
+To get started you'll have to :
+
+1. install [Nuke.GlobalTool] dotnet tool (locally or globally)
+2. run `dotnet nuke :setup` to setup your pipeline project
+3. replace the `Nuke.Common` nuget dependency with [Candoumbe.Pipelines]
+
+From this point, you should be able to customize your pipeline by adding [components] \o/.
+
+### How does it works ?
+
+This library is built on top of [Nuke], an open source library started by [Mathias Klock].
+It provides a set of components that, when added to a pipeline, bring clever default features.
+
+Components are C# interfaces that come with a default / opinionated implementation.
+They are grouped in namespaces which correspond to their main task.
+
+- `Candoumbe.Pipelines.Components` : contains the core components needed for general required tasks.
+
+Let's say you have the following `Build.cs` class as your starting pipeline
+
+```csharp
+class Build : NukeBuild
+{
+    public static void Main() => Execute<Build>(x => x.Compile());
+
+    Target Compile => _ => _
+        .Executes(() => {
+
+            // Code omitted for brievity
+
+        });
+}
+```
+
+you can get rid of the `Compile` property and use the [ICompile] component instead.
+
+```csharp
+class Build : NukeBuild, ICompile
+{
+    public static void Main() => Execute<Build>(x => ((ICompile)x).Compile());
+
+}
+```
+
+In the example above, the build pipeline benefits from the [ICompile] component which comes with a default implementation of the `Compile` target.
+
+#### `Candoumbe.Pipelines.Components.Workflows`
+
+Contains components related to branching strategies and providing tools that can help normalize how teams
+works in.
+
+[IGitFlow] and [IGitHubFlow] are two components that helps handle branching strategy locally.
+
+- GitFlow
+
+```mermaid
+%%{init: {"flowchart": {"htmlLabels": false}} }%%
+flowchart LR
+    A((start)) --> B["run ./build feature"]
+    B --> C{is on 'feature/*' branch ?}
+    C -- no --> D[Creates a new feature/* branch]
+    C -- yes --> F
+    subgraph finish-feature
+      F[Update changelog] --> G[validate changelog modifications]
+      G --> H[Merges changes to develop branch]
+    end
+    finish-feature --> Z((end))
+    D --> Z
+```
+
+- GitHubFlow
+
+```mermaid
+%%{init: {"flowchart": {"htmlLabels": false}} }%%
+flowchart LR
+    A((start)) --> B["run ./build feature"]
+    B --> C{is on 'feature/*' branch ?}
+    C -- no --> D[Creates a new feature/* branch]
+    C -- yes --> F
+    subgraph finish-feature
+      F[Update changelog] --> G[validate changelog modifications]
+      G --> H[Merges changes to main/master branch]
+    end
+    finish-feature --> Z((end))
+    D --> Z
+```
+
+Some components are used to set the workflow to use throughout a repository and streamline the work of a developer and a team.
+
+ Both [`IGitFlowWithPullRequest`] and [`IGithubFlowWithPullRequest`] were created with that goal in mind.
+
+#### `Candoumbe.Pipelines.Components.NuGet`
+
+Contains classes required to push nuget packages to repositories.
+
+#### `Candoumbe.Pipelines.Components.GitHub`
+
+Contains classes and components needed to interact with GitHub repositories (creating pull requests).
+
+#### `Candoumbe.Pipelines.Components.Docker`
+
+Contains classes and components needed to build and push docker images.
+
+⚠️ **Some components may require additional packages and/or tools to be installed in order to be fully functional.**
+**For example, the default implementation of `IMutationTest` uses [`Stryker`](https://nuget.org/packages/stryker) to run mutation tests**.
+
+You can refer to [Nuke's documentation](https://www.nuke.build/docs/common/cli-tools/) to see how to reference required tools.
+
+### Want to contribute ?
+
+You can contribute by opening an [issue](https://github.com/candoumbe/Pipelines/issues/new/choose) or submitting a feature request.
+
+PRs are welcome  (check out the [contribution guidelines] if you want to contribute to this project) !
+
+## Special thanks
 
 - [Nuke] as the engine behind the scene
 
-[Nuke]: https//nuke.build
+[Nuke]: https//github.com/nuke/
+[Nuke.GlobalTool]: https://nuget.org/packages/Nuke.GlobalTool
+[Mathias Klock]: dummy@email.com
+[Candoumbe.Pipelines]: https://nuget.org/packages/Candoumbe.Pipelines
+[contribution guidelines]: CONTRIBUTING.md
+[semantic versioning]: https://semver.org/spec/v2.0.0.html
+[ICompile]: ./src/Candoumbe.Pipelines/Components/ICompile.cs
+[IGitFlow]: ./src/Candoumbe.Pipelines/Components/Workflows/IGitFlow.cs
+[IGitHubFlow]: ./src/Candoumbe.Pipelines/Components/Workflows/IGitHubFlow.cs

--- a/src/Candoumbe.Pipelines/Components/GitHub/ICreateGithubRelease.cs
+++ b/src/Candoumbe.Pipelines/Components/GitHub/ICreateGithubRelease.cs
@@ -32,11 +32,11 @@ public interface ICreateGithubRelease : IHaveGitHubRepository, IHaveChangeLog, I
     /// </summary>
     public Target AddGithubRelease => _ => _
         .Unlisted()
-        .OnlyWhenStatic(() => !string.IsNullOrWhiteSpace(GitHubToken))
+        .OnlyWhenDynamic(() => !string.IsNullOrWhiteSpace(GitHubToken))
+        .OnlyWhenDynamic(() => GitRepository.IsOnMainBranch())
         .TryTriggeredBy<IPushNugetPackages>(x => x.Publish)
         .TryTriggeredBy<IPushDockerImages>(x => x.PushImages)
         .Description("Creates a new GitHub release after artifacts were successfully published.")
-        .OnlyWhenDynamic(() => GitRepository.IsOnMainBranch())
         .Executes(async () =>
         {
             string repositoryName = GitRepository.GetGitHubName();

--- a/src/Candoumbe.Pipelines/Components/GitHub/IHaveGitHubRepository.cs
+++ b/src/Candoumbe.Pipelines/Components/GitHub/IHaveGitHubRepository.cs
@@ -13,5 +13,5 @@ public interface IHaveGitHubRepository : IHaveGitRepository, IHaveSecret
     /// </summary>
     [Parameter("Token used to create a new release in GitHub")]
     [Secret]
-    string GitHubToken => TryGetValue(() => GitHubToken) ?? GitHubActions.Instance.Token;
+    string GitHubToken => TryGetValue(() => GitHubToken) ?? GitHubActions.Instance?.Token;
 }

--- a/src/Candoumbe.Pipelines/Components/NuGet/IPushNugetPackages.cs
+++ b/src/Candoumbe.Pipelines/Components/NuGet/IPushNugetPackages.cs
@@ -87,7 +87,7 @@ public interface IPushNugetPackages : IPack
             }
             else
             {
-                PushNugetPackageConfiguration publishConfiguration = PublishConfigurations.Single(config => config.Name == ConfigName);
+                PushNugetPackageConfiguration publishConfiguration = PublishConfigurations.Single(config => string.Equals(config.Name, ConfigName, System.StringComparison.OrdinalIgnoreCase));
                 DotNetNuGetPush(s => s.Apply(PublishSettingsBase)
                                       .Apply(PublishSettings)
                                       .When(publishConfiguration.CanBeUsed(),

--- a/src/Candoumbe.Pipelines/Components/NuGet/IPushNugetPackages.cs
+++ b/src/Candoumbe.Pipelines/Components/NuGet/IPushNugetPackages.cs
@@ -31,14 +31,14 @@ public interface IPushNugetPackages : IPack
     /// <summary>
     /// Explicitely
     /// </summary>
-    [Parameter("Which specific configuration to publish packages to.")]
+    [Parameter("Defines the name of the configuration to use to publish packages.")]
     public string ConfigName => TryGetValue(() => ConfigName)?.Trim();
 
     /// <summary>
     /// Publish all <see cref="PublishPackageFiles"/> to <see cref="PublishConfigurations"/>.
     /// </summary>
     public Target Publish => _ => _
-        .Description($"Published packages (*.nupkg and *.snupkg) to the destination server set using either {nameof(PublishConfigurations)} settings or {ConfigName} configuration ")
+        .Description($"Published packages (*.nupkg and *.snupkg) to the destination server set using either {nameof(PublishConfigurations)} settings or the configuration {nameof(ConfigName)} configuration ")
         .Consumes(Pack, ArtifactsDirectory / "*.nupkg", ArtifactsDirectory / "*.snupkg")
         .DependsOn(Pack)
         .OnlyWhenDynamic(() => (!string.IsNullOrWhiteSpace(ConfigName) && PublishConfigurations.Once(config => config.Name == ConfigName))

--- a/src/Candoumbe.Pipelines/Components/NuGet/IPushNugetPackages.cs
+++ b/src/Candoumbe.Pipelines/Components/NuGet/IPushNugetPackages.cs
@@ -45,7 +45,8 @@ public interface IPushNugetPackages : IPack
                                 || PublishConfigurations.AtLeastOnce(config => config.CanBeUsed()))
         .WhenNotNull(this as IHaveGitRepository,
                      (_, repository) => _.Requires(() => GitHasCleanWorkingCopy())
-                                         .OnlyWhenDynamic(() => repository.GitRepository.IsOnMainOrMasterBranch()
+                                         .OnlyWhenDynamic(() => IsLocalBuild
+                                                                || repository.GitRepository.IsOnMainOrMasterBranch()
                                                                 || repository.GitRepository.IsOnReleaseBranch()
                                                                 || repository.GitRepository.IsOnHotfixBranch()))
         .Requires(() => Configuration.Equals(Configuration.Release))

--- a/src/Candoumbe.Pipelines/Components/NuGet/PushNugetPackageConfiguration.cs
+++ b/src/Candoumbe.Pipelines/Components/NuGet/PushNugetPackageConfiguration.cs
@@ -5,7 +5,7 @@ namespace Candoumbe.Pipelines.Components.NuGet;
 /// <summary>
 /// Wraps configuration used to push nuget packages
 /// </summary>
-/// <param name="Name">Name of the configuration. Should uniquely identifies a configuration and </param>
+/// <param name="Name">Name of the configuration. Should uniquely identifies a configuration.</param>
 /// <param name="Key">API key used to interact with the API</param>
 /// <param name="Source">Source to the package repository</param>
 /// <param name="CanBeUsed">Lazily check if the current configuration can be used.</param>


### PR DESCRIPTION
### 🚀 New features
• Added ConfigName parameter to specify the name of the configuration to use when pushing nuget packages ([#37](https://github.com/candoumbe/Pipelines/issues/37)).
• Changes requirements of IPushNugetPackages.Publish target to make it runnable locally

Full changelog at https://github.com/candoumbe/Pipelines/blob/feature/pulish-nupkg-by-specifying-config-name/CHANGELOG.md

Resolves #37