### PR TITLE
[FEATURE] Add Default Cli Options To Run Mutation Tests Faster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `ConfigName` parameter to specify the name of the configuration to use when pushing nuget packages ([#37](https://github.com/candoumbe/Pipelines/issues/37)).
 - Changes requirements of `IPushNugetPackages.Publish` target to make it runnable locally
 
+### 🧹 Housekeeping
+- Adds [`--with-baseline`](https://stryker-mutator.io/docs/stryker-net/configuration/#baseline) an and [`--version`](https://stryker-mutator.io/docs/stryker-net/configuration/#project-infoversion-committish) arguments to run mutation tests with Stryker faster
+
 ## [0.4.5] / 2023-07-17
 ### 🔧 Fixes
 - Reverted changes made to output tests result in a folder that is named after the current branch (if any).

--- a/src/Candoumbe.Pipelines/Components/IUnitTest.cs
+++ b/src/Candoumbe.Pipelines/Components/IUnitTest.cs
@@ -48,13 +48,14 @@ public interface IUnitTest : ICompile, IHaveTests, IHaveCoverage
                 .Apply(UnitTestSettingsBase)
                 .Apply(UnitTestSettings)
                 .CombineWith(UnitTestsProjects, (cs, project) => cs.SetProjectFile(project)
-                                                               .CombineWith(project.GetTargetFrameworks(), (setting, framework) => setting.Apply<DotNetTestSettings, (Project, string)>(ProjectUnitTestSettingsBase, (project, framework))
-                                                                                                                                          .Apply<DotNetTestSettings, (Project, string)>(ProjectUnitTestSettings, (project, framework))
+                                                               .CombineWith(project.GetTargetFrameworks(),
+                                                                            (setting, framework) => setting.Apply<DotNetTestSettings, (Project, string)>(ProjectUnitTestSettingsBase, (project, framework))
+                                                                                                           .Apply<DotNetTestSettings, (Project, string)>(ProjectUnitTestSettings, (project, framework))
                     )));
 
             TestResultDirectory.GlobFiles("*.trx")
                                .ForEach(testFileResult => AzurePipelines.Instance?.PublishTestResults(title: $"{Path.GetFileNameWithoutExtension(testFileResult)} ({AzurePipelines.Instance.StageDisplayName})",
-type: AzurePipelinesTestResultsType.VSTest,
+                                                                                                      type: AzurePipelinesTestResultsType.VSTest,
                                                                                                       files: new string[] { testFileResult })
                     );
 

--- a/src/Candoumbe.Pipelines/Components/Workflows/IGitFlow.cs
+++ b/src/Candoumbe.Pipelines/Components/Workflows/IGitFlow.cs
@@ -30,6 +30,14 @@ public interface IGitFlow : IWorkflow, IHaveDevelopBranch
     /// </summary>
     public string ReleaseBranchPrefix => "release";
 
+    /// <summary>
+    /// Defines the name of the branch where a "coldfix/*" branch should be merged back to (once finished).
+    /// </summary>
+    /// <remarks>
+    /// This property should never return <see langword="null"/>.
+    /// </remarks>
+    string ColdfixBranchSourceName => FeatureBranchSourceName;
+
     ///<inheritdoc/>
     string IWorkflow.FeatureBranchSourceName => DevelopBranchName;
 

--- a/src/Candoumbe.Pipelines/Components/Workflows/IWorkflow.cs
+++ b/src/Candoumbe.Pipelines/Components/Workflows/IWorkflow.cs
@@ -35,11 +35,16 @@ public interface IWorkflow : IHaveGitRepository, IHaveMainBranch, IHaveGitVersio
     /// <summary>
     /// Name of the branch to use when starting a new feature
     /// </summary>
+    /// <remarks>
+    /// This property should never return <see langword="null"/>
     string FeatureBranchSourceName { get; }
 
     /// <summary>
     /// Name of the branch to use when starting a new hotfix branch
     /// </summary>
+    /// </remarks
+    /// This property should never return <see langword="null"/>
+    /// </remarks>
     string HotfixBranchSourceName { get; }
 
     /// <summary>


### PR DESCRIPTION
### 🚀 New features
• Added ConfigName parameter to specify the name of the configuration to use when pushing nuget packages ([#37](https://github.com/candoumbe/Pipelines/issues/37)).
• Changes requirements of IPushNugetPackages.Publish target to make it runnable locally
### 🧹 Housekeeping
• Adds [--with-baseline](https://stryker-mutator.io/docs/stryker-net/configuration/#baseline) an and [--version](https://stryker-mutator.io/docs/stryker-net/configuration/#project-infoversion-committish) arguments to run mutation tests with Stryker faster

Full changelog at https://github.com/candoumbe/Pipelines/blob/feature/add-default-cli-options-to-run-mutation-tests-faster/CHANGELOG.md