### PR TITLE
[COLDFIX] Invalid Cast Operation When Calling Mutation Tests Target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### 🚀 New features
 - Added `ConfigName` parameter to specify the name of the configuration to use when pushing nuget packages ([#37](https://github.com/candoumbe/Pipelines/issues/37)).
-- Changes requirements of `IPushNugetPackages.Publish` target to make it runnable locally
+- Changed requirements of `IPushNugetPackages.Publish` target to make it runnable locally
 
 ### 🧹 Housekeeping
-- Adds [`--with-baseline`](https://stryker-mutator.io/docs/stryker-net/configuration/#baseline) an and [`--version`](https://stryker-mutator.io/docs/stryker-net/configuration/#project-infoversion-committish) arguments to run mutation tests with Stryker faster
+- Added [`--with-baseline`](https://stryker-mutator.io/docs/stryker-net/configuration/#baseline) an and [`--version`](https://stryker-mutator.io/docs/stryker-net/configuration/#project-infoversion-committish) arguments to run mutation tests with Stryker faster
+- Updated `Candoumbe.MiscUtilities` to `0.11.1`.
 
 ## [0.4.5] / 2023-07-17
 ### 🔧 Fixes

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,5 +1,20 @@
 mode: ContinuousDeployment
-branches: {}
+branches: {
+  feature: {
+    regex: "^feature(s)?[/-]",
+  },
+  coldfix: {
+    regex: "^coldfix(es)?[/-]",
+    source-branches: ["develop"]
+  },
+  release: {
+    regex: "^release(s)?[/-]",
+    tag: "rc"
+  },
+  develop: {
+    tag: "alpha"
+  }
+}
 ignore:
   sha: []
 merge-message-formats: {}

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,20 +1,24 @@
 mode: ContinuousDeployment
-branches: {
-  feature: {
-    regex: "^feature(s)?[/-]",
-  },
-  coldfix: {
-    regex: "^coldfix(es)?[/-]",
-    source-branches: ["develop"]
-  },
-  release: {
-    regex: "^release(s)?[/-]",
+branches: 
+  feature: 
+    regex: "^feature(s)?[/-]"
+  coldfix:
+    regex: "^coldfix(es)?[/-]"
+    mode: ContinuousDelivery
+    tag: useBranchName
+    increment: Inherit
+    prevent-increment-of-merged-branch-version: false
+    track-merge-target: false
+    source-branches: [ 'develop', 'feature', 'support', 'hotfix' ]
+    tracks-release-branches: false
+    is-release-branch: false
+    is-mainline: false
+    pre-release-weight: 30000
+  release:
+    regex: "^release(s)?[/-]"
     tag: "rc"
-  },
-  develop: {
+  develop: 
     tag: "alpha"
-  }
-}
 ignore:
   sha: []
 merge-message-formats: {}

--- a/build/Candoumbe.Pipelines.Build.csproj
+++ b/build/Candoumbe.Pipelines.Build.csproj
@@ -66,7 +66,7 @@
   
   <ItemGroup>
     <PackageReference Include="Nuke.Common" Version="7.0.2" PrivateAssets="all"/>
-    <PackageReference Include="Candoumbe.MiscUtilities" Version="0.11.0" />
+    <PackageReference Include="Candoumbe.MiscUtilities" Version="0.11.1" />
     <PackageDownload Include="GitVersion.Tool" Version="[5.12.0]" />
   </ItemGroup>
 </Project>

--- a/core.props
+++ b/core.props
@@ -43,6 +43,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Candoumbe.Miscutilities" Version="0.11.0"/>
+    <PackageReference Include="Candoumbe.Miscutilities" Version="0.11.1"/>
   </ItemGroup>
 </Project>

--- a/src/Candoumbe.Pipelines/Components/Docker/IBuildDockerImage.cs
+++ b/src/Candoumbe.Pipelines/Components/Docker/IBuildDockerImage.cs
@@ -3,6 +3,7 @@ using Nuke.Common.Tooling;
 using Nuke.Common.Tools.Docker;
 using Nuke.Common.Utilities.Collections;
 
+using System;
 using System.Collections.Generic;
 
 using static Nuke.Common.Tools.Docker.DockerTasks;
@@ -27,7 +28,7 @@ public interface IBuildDockerImage : IHaveConfiguration
         .OnlyWhenStatic(() => DockerFiles.AtLeastOnce())
         .Executes(() =>
         {
-            ReportSummary(_ => _.WhenNotNull(this as IHaveGitVersion,
+            ReportSummary(_ => _.WhenNotNull(this.As<IHaveGitVersion>(),
                                              (_, version) => _.AddPair("Version", version.GitVersion.FullSemVer)));
 
             DockerBuild(s => s

--- a/src/Candoumbe.Pipelines/Components/Extensions.cs
+++ b/src/Candoumbe.Pipelines/Components/Extensions.cs
@@ -29,6 +29,7 @@ public static class Extensions
     /// </summary>
     /// <typeparam name="T"></typeparam>
     /// <param name="nukeBuild"></param>
+    /// <exception cref="InvalidCastException">if <paramref name="nukeBuild"/> is not convertible to <typeparamref name="T"/>.</exception>
     public static T Get<T>(this INukeBuild nukeBuild) where T : INukeBuild
         => (T)(object)nukeBuild;
 }

--- a/src/Candoumbe.Pipelines/Components/GitHub/IGitHubFlowWithPullRequest.cs
+++ b/src/Candoumbe.Pipelines/Components/GitHub/IGitHubFlowWithPullRequest.cs
@@ -48,7 +48,7 @@ namespace Candoumbe.Pipelines.Components.GitHub
         /// Description of the pull request
         /// </summary>
         [Parameter("Description of the pull request")]
-        string Description => TryGetValue(() => Description) ?? this.Get<IHaveChangeLog>()?.ReleaseNotes;
+        string Description => TryGetValue(() => Description) ?? this.As<IHaveChangeLog>()?.ReleaseNotes;
 
         /// <summary>
         /// Should the local branch be deleted after the pull request was created successfully ?

--- a/src/Candoumbe.Pipelines/Components/GitHub/IPullRequest.cs
+++ b/src/Candoumbe.Pipelines/Components/GitHub/IPullRequest.cs
@@ -27,7 +27,7 @@ namespace Candoumbe.Pipelines.Components.GitHub
         /// Description of the pull request
         /// </summary>
         [Parameter("Description of the pull request")]
-        string Description => TryGetValue(() => Description) ?? this.Get<IHaveChangeLog>()?.ReleaseNotes;
+        string Description => TryGetValue(() => Description) ?? this.As<IHaveChangeLog>()?.ReleaseNotes;
 
         /// <summary>
         /// Should the local branch be deleted after the pull request was created successfully ?

--- a/src/Candoumbe.Pipelines/Components/ICompile.cs
+++ b/src/Candoumbe.Pipelines/Components/ICompile.cs
@@ -27,7 +27,7 @@ public interface ICompile : IRestore, IHaveConfiguration
         {
             Information("Compiling {Solution}", Solution);
 
-            ReportSummary(_ => _.WhenNotNull(this as IHaveGitVersion,
+            ReportSummary(_ => _.WhenNotNull(this.As<IHaveGitVersion>(),
                                              (_, version) => _.AddPair("Version", version.GitVersion.FullSemVer)));
 
             DotNetBuild(s => s
@@ -44,7 +44,7 @@ public interface ICompile : IRestore, IHaveConfiguration
                 .SetProjectFile(Solution)
                 .SetConfiguration(Configuration)
                 .SetContinuousIntegrationBuild(IsServerBuild)
-                .WhenNotNull(this as IHaveGitVersion,
+                .WhenNotNull(this.As<IHaveGitVersion>(),
                              (settings, gitVersion) => settings.SetAssemblyVersion(gitVersion.GitVersion.AssemblySemVer)
                                                                .SetFileVersion(gitVersion.GitVersion.AssemblySemFileVer)
                                                                .SetInformationalVersion(gitVersion.GitVersion.InformationalVersion)

--- a/src/Candoumbe.Pipelines/Components/IHaveTests.cs
+++ b/src/Candoumbe.Pipelines/Components/IHaveTests.cs
@@ -17,5 +17,6 @@ public interface IHaveTests : IHaveArtifacts
     /// </summary>
     /// <remarks>
     /// By default, the root directory for all test result will be will be in <c>{ArtifactsDirectory} / "tests-results"</c>
+    /// </remarks>
     public AbsolutePath TestResultDirectory => ArtifactsDirectory / TestResultDirectoryName;
 }

--- a/src/Candoumbe.Pipelines/Components/IMutationTest.cs
+++ b/src/Candoumbe.Pipelines/Components/IMutationTest.cs
@@ -143,16 +143,16 @@ public interface IMutationTest : IUnitTest
            .Add("--reporter markdown")
            .Add("--reporter html")
            .When(IsLocalBuild, args => args.Add("--reporter progress"))
-           .WhenNotNull(this.Get<IGitFlow>()?.GitRepository?.Branch,
+           .WhenNotNull(this.As<IGitFlow>()?.GitRepository?.Branch,
                         (args, branch) => args.Add("--with-baseline:{0}", branch.ToLowerInvariant() switch
                         {
                             string branchName when branchName == IGitFlow.MainBranchName || branchName == IGitFlow.DevelopBranchName => branchName,
-                            string branchName when branchName.Like($"{this.Get<IGitFlow>().FeatureBranchPrefix}/*", true) => this.Get<IWorkflow>().FeatureBranchSourceName,
-                            string branchName when branchName.Like($"{this.Get<IGitFlow>().HotfixBranchPrefix}/*", true) => this.Get<IWorkflow>().HotfixBranchSourceName,
-                            string branchName when branchName.Like($"{this.Get<IGitFlow>().ColdfixBranchPrefix}/*", true) => this.Get<IGitFlow>().ColdfixBranchSourceName,
+                            string branchName when branchName.Like($"{this.As<IGitFlow>()?.FeatureBranchPrefix}/*", true) => this.As<IWorkflow>().FeatureBranchSourceName,
+                            string branchName when branchName.Like($"{this.As<IGitFlow>()?.HotfixBranchPrefix}/*", true) => this.As<IWorkflow>().HotfixBranchSourceName,
+                            string branchName when branchName.Like($"{this.As<IGitFlow>()?.ColdfixBranchPrefix}/*", true) => this.As<IGitFlow>().ColdfixBranchSourceName,
                             _ => IGitFlow.MainBranchName
                         }))
-           .WhenNotNull(this.Get<IGitHubFlow>(), (args, flow) => args.Add("--with-baseline:{0}", IGitHubFlow.MainBranchName)
+           .WhenNotNull(this.As<IGitHubFlow>(), (args, flow) => args.Add("--with-baseline:{0}", IGitHubFlow.MainBranchName)
                                                                   .Add("--version:{0}", flow.GitRepository?.Commit ?? flow.GitRepository?.Branch));
 
     /// <summary>

--- a/src/Candoumbe.Pipelines/Components/IPack.cs
+++ b/src/Candoumbe.Pipelines/Components/IPack.cs
@@ -5,6 +5,7 @@ using Nuke.Common.Tools.DotNet;
 using Nuke.Common.Tools.GitVersion;
 using Nuke.Common.Utilities.Collections;
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -63,12 +64,12 @@ public interface IPack : IHaveArtifacts, ICompile
         .SetNoRestore(SucceededTargets.Contains(Restore) || SucceededTargets.Contains(Compile))
         .SetConfiguration(Configuration)
         .SetSymbolPackageFormat(DotNetSymbolPackageFormat.snupkg)
-        .WhenNotNull(this as IHaveGitVersion,
+        .WhenNotNull(this.As<IHaveGitVersion>(),
                      (_, versioning) => _.SetAssemblyVersion(versioning.GitVersion.AssemblySemVer)
                                         .SetFileVersion(versioning.GitVersion.AssemblySemFileVer)
                                         .SetInformationalVersion(versioning.GitVersion.InformationalVersion)
                                         .SetVersion(versioning.GitVersion.NuGetVersion))
-        .WhenNotNull(this as IHaveChangeLog, (_, changelog) => _.SetPackageReleaseNotes(changelog.ReleaseNotes))
-        .WhenNotNull(this as IHaveGitRepository, (_, repository) => _.SetRepositoryType("git")
+        .WhenNotNull(this.As<IHaveChangeLog>(), (_, changelog) => _.SetPackageReleaseNotes(changelog.ReleaseNotes))
+        .WhenNotNull(this.As<IHaveGitRepository>(), (_, repository) => _.SetRepositoryType("git")
                                                                      .SetRepositoryUrl(repository.GitRepository.HttpsUrl));
 }

--- a/src/Candoumbe.Pipelines/Components/IReportCoverage.cs
+++ b/src/Candoumbe.Pipelines/Components/IReportCoverage.cs
@@ -7,6 +7,7 @@ using Nuke.Common.Tools.Codecov;
 using Nuke.Common.Tools.DotNet;
 using Nuke.Common.Tools.ReportGenerator;
 
+using System;
 using System.Linq;
 
 using static Nuke.Common.Tools.Codecov.CodecovTasks;
@@ -54,9 +55,9 @@ public interface IReportCoverage : IUnitTest
         .SetFiles(UnitTestResultsDirectory.GlobFiles("*.xml").Select(x => x.ToString()))
         .SetToken(CodecovToken)
         .SetFramework("netcoreapp3.0")
-        .WhenNotNull(this as IHaveGitVersion,
+        .WhenNotNull(this.As<IHaveGitVersion>(),
                      (_, version) => _.SetBuild(version.GitVersion.FullSemVer))
-        .WhenNotNull(this as IHaveGitRepository,
+        .WhenNotNull(this.As<IHaveGitRepository>(),
                      (_, repository) => _.SetBranch(repository.GitRepository.Branch)
                                          .SetSha(repository.GitRepository.Commit));
 
@@ -72,7 +73,7 @@ public interface IReportCoverage : IUnitTest
         .SetFramework("net5.0")
         .SetReports(UnitTestResultsDirectory / "*.xml")
         .SetReportTypes(ReportTypes.Badges, ReportTypes.HtmlChart, ReportTypes.HtmlInline)
-        .WhenNotNull((this as IHaveGitRepository)?.GitRepository,
+        .WhenNotNull(this.As<IHaveGitRepository>()?.GitRepository,
                      (_, repository) => !string.IsNullOrWhiteSpace(repository.Branch)
                                         ? _.SetTargetDirectory(CoverageReportDirectory / repository.Branch)
                                           .SetHistoryDirectory(CoverageReportHistoryDirectory / repository.Branch)
@@ -81,7 +82,7 @@ public interface IReportCoverage : IUnitTest
                            .SetHistoryDirectory(CoverageReportHistoryDirectory)
                            .SetTag(repository.Commit)
                      )
-        .When(this.Get<IHaveGitRepository>() is null,
+        .When(this.As<IHaveGitRepository>() is null,
               _ => _.SetTargetDirectory(CoverageReportDirectory)
                     .SetHistoryDirectory(CoverageReportHistoryDirectory));
 

--- a/src/Candoumbe.Pipelines/Components/NuGet/IPushNugetPackages.cs
+++ b/src/Candoumbe.Pipelines/Components/NuGet/IPushNugetPackages.cs
@@ -4,6 +4,7 @@ using Nuke.Common.IO;
 using Nuke.Common.Tooling;
 using Nuke.Common.Tools.DotNet;
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -43,7 +44,7 @@ public interface IPushNugetPackages : IPack
         .DependsOn(Pack)
         .OnlyWhenDynamic(() => (!string.IsNullOrWhiteSpace(ConfigName) && PublishConfigurations.Once(config => config.Name == ConfigName))
                                 || PublishConfigurations.AtLeastOnce(config => config.CanBeUsed()))
-        .WhenNotNull(this as IHaveGitRepository,
+        .WhenNotNull(this.As<IHaveGitRepository>(),
                      (_, repository) => _.Requires(() => GitHasCleanWorkingCopy())
                                          .OnlyWhenDynamic(() => IsLocalBuild
                                                                 || repository.GitRepository.IsOnMainOrMasterBranch()

--- a/src/Candoumbe.Pipelines/Components/Workflows/IWorkflow.cs
+++ b/src/Candoumbe.Pipelines/Components/Workflows/IWorkflow.cs
@@ -37,13 +37,14 @@ public interface IWorkflow : IHaveGitRepository, IHaveMainBranch, IHaveGitVersio
     /// </summary>
     /// <remarks>
     /// This property should never return <see langword="null"/>
+    /// </remarks>
     string FeatureBranchSourceName { get; }
 
     /// <summary>
     /// Name of the branch to use when starting a new hotfix branch
     /// </summary>
-    /// </remarks
-    /// This property should never return <see langword="null"/>
+    /// <remarks>
+    /// This property should never return <see langword="null"/>.
     /// </remarks>
     string HotfixBranchSourceName { get; }
 


### PR DESCRIPTION
### 🚀 New features
• Added ConfigName parameter to specify the name of the configuration to use when pushing nuget packages ([#37](https://github.com/candoumbe/Pipelines/issues/37)).
• Changed requirements of IPushNugetPackages.Publish target to make it runnable locally
### 🧹 Housekeeping
• Added [--with-baseline](https://stryker-mutator.io/docs/stryker-net/configuration/#baseline) an and [--version](https://stryker-mutator.io/docs/stryker-net/configuration/#project-infoversion-committish) arguments to run mutation tests with Stryker faster
• Updated `Candoumbe.MiscUtilities` to `0.11.1`.

Full changelog at https://github.com/candoumbe/Pipelines/blob/coldfix/invalid-cast-operation-when-calling-mutation-tests-target/CHANGELOG.md