### PR TITLE
[FEATURE] Reduce Cli Options Sent To The Unit Tests Target To Minimum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixes
+- Reduced the number of CLI options sent when `IUnitTest.UnitTests` target runs and the current build does not need to collect code coverage.
 
 ## [0.5.0] / 2023-07-24
 ### 🚀 New features


### PR DESCRIPTION
### Fixes
• Reduced the number of CLI options sent when IUnitTest.UnitTests target runs and the current build does not need to collect code coverage.

Full changelog at https://github.com/candoumbe/Pipelines/blob/feature/reduce-cli-options-sent-to-the-unit-tests-target-to-minimum/CHANGELOG.md