### PR TITLE
[FEATURE] Push Mutation Result To Stryker Dashboard When Possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixes
+- Added CLI options to push mutation reports to stryker dashboard when possible.
+- Made `IMutationTest.MutationTests` target to run before `IPack.Pack`.
+
 
 ## [0.5.0] / 2023-07-24
 ### 🚀 New features

--- a/src/Candoumbe.Pipelines/Components/Extensions.cs
+++ b/src/Candoumbe.Pipelines/Components/Extensions.cs
@@ -1,4 +1,5 @@
 ﻿using Nuke.Common;
+using Nuke.Common.ProjectModel;
 
 using System;
 
@@ -32,4 +33,14 @@ public static class Extensions
     /// <exception cref="InvalidCastException">if <paramref name="nukeBuild"/> is not convertible to <typeparamref name="T"/>.</exception>
     public static T Get<T>(this INukeBuild nukeBuild) where T : INukeBuild
         => (T)(object)nukeBuild;
+
+    /// <summary>
+    /// Uses various heuristics to tests if <paramref name="project"/> has <see href="https://github.com/dotnet/sourcelink">SourceLink</see>
+    /// enabled .
+    /// </summary>
+    /// <param name="project"></param>
+    /// <returns><see langword="true"/> if <see href="https://github.com/dotnet/sourcelink">SourceLink</see>
+    /// enabled and <see langword="false"/> otherwise</returns>
+    public static bool IsSourceLinkEnabled(this Project project) => false;
+
 }


### PR DESCRIPTION
### Fixes
• Added CLI options to push mutation reports to stryker dashboard when possible.
• Made IMutationTest.MutationTests target to run before IPack.Pack.

Full changelog at https://github.com/candoumbe/Pipelines/blob/feature/push-mutation-result-to-stryker-dashboard-when-possible/CHANGELOG.md