### PR TITLE
[FEATURE] Push Mutation Result To Stryker Dashboard When Possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reduced the number of CLI options sent when `IUnitTest.UnitTests` target runs and the current build does not need to collect code coverage.
 - Added CLI options to push mutation reports to stryker dashboard when possible.
 - Made `IMutationTest.MutationTests` target to run before `IPack.Pack` does.
+- Added CLI option `--project` to the options output when running mutation tests
 
 ## [0.5.0] / 2023-07-24
 ### 🚀 New features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-### Fixes
+### 🔧 Fixes
 - Reduced the number of CLI options sent when `IUnitTest.UnitTests` target runs and the current build does not need to collect code coverage.
 - Added CLI options to push mutation reports to stryker dashboard when possible.
-- Made `IMutationTest.MutationTests` target to run before `IPack.Pack`.
+- Made `IMutationTest.MutationTests` target to run before `IPack.Pack` does.
 
 ## [0.5.0] / 2023-07-24
 ### 🚀 New features

--- a/src/Candoumbe.Pipelines/Components/IMutationTest.cs
+++ b/src/Candoumbe.Pipelines/Components/IMutationTest.cs
@@ -136,6 +136,8 @@ public interface IMutationTest : IUnitTest
         strykerArgs = strykerArgs.Add("stryker");
         strykerArgs = strykerArgs.Concatenate(args);
 
+        strykerArgs.Add(@"--project {value}", sourceProject.Name);
+
         testsProjects.ForEach(project =>
         {
             strykerArgs = strykerArgs.Add(@"--test-project {value}", project.Path);


### PR DESCRIPTION
### 🔧 Fixes
• Reduced the number of CLI options sent when IUnitTest.UnitTests target runs and the current build does not need to collect code coverage.
• Added CLI options to push mutation reports to stryker dashboard when possible.
• Made IMutationTest.MutationTests target to run before IPack.Pack does.
• Added CLI option --project to the options output when running mutation tests

Full changelog at https://github.com/candoumbe/Pipelines/blob/feature/push-mutation-result-to-stryker-dashboard-when-possible/CHANGELOG.md

Resolves #86