### PR TITLE
[COLDFIX] Remove Nofetch Option When Calling Gitversion

### DIFF
--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -165,11 +165,6 @@
           "type": "string",
           "description": "Title that will be used when creating a PR"
         },
-        "Token": {
-          "type": "string",
-          "description": "Token used to create a pull request",
-          "default": "Secrets must be entered via 'nuke :secrets [profile]'"
-        },
         "Verbosity": {
           "type": "string",
           "description": "Logging verbosity during build execution. Default is 'Normal'",

--- a/.nuke/parameters.json
+++ b/.nuke/parameters.json
@@ -2,6 +2,5 @@
   "$schema": "./build.schema.json",
   "Solution": "Candoumbe.Pipelines.sln",
   "NoLogo": true,
-  "DeleteLocalOnSuccess": true,
-  "GitHubToken": "v1:rDcK7lT0St3/CdfzkxuYhLorDhZnwEqMT04dx8RX2V7hx2q8sr69ohhzFC7OtEvVNOybOTnrXQuar7ZxXiWk3fkpNlyJUGR5gKPZX7v1w9iwzXjXkFFqpgumXWK5tPKW"
+  "DeleteLocalOnSuccess": true
 }

--- a/.nuke/parameters.json
+++ b/.nuke/parameters.json
@@ -2,5 +2,6 @@
   "$schema": "./build.schema.json",
   "Solution": "Candoumbe.Pipelines.sln",
   "NoLogo": true,
-  "DeleteLocalOnSuccess": true
+  "DeleteLocalOnSuccess": true,
+  "GitHubToken": "v1:rDcK7lT0St3/CdfzkxuYhLorDhZnwEqMT04dx8RX2V7hx2q8sr69ohhzFC7OtEvVNOybOTnrXQuar7ZxXiWk3fkpNlyJUGR5gKPZX7v1w9iwzXjXkFFqpgumXWK5tPKW"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "dotnet.defaultSolution": "Candoumbe.Pipelines.sln"
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### 🚨 Breaking changes
+
+- Removes `Github.IPullRequest.Token` property. This property was previously used by `GitHub.IGitFlowWithPullRequest` and `GitHub.IGitFlowWithPullRequest` when finishing a feature/coldfix is.
+
+### 🛠️ Fixes
+
+- Removes `nofetch` option when calling `gitversion` tool.
+
+### 🧹 Housekeeping
+
+- Add `GitHubToken` value in `parameters.json` : this value will be consumed directly to interact with the github repository.
 
 ## [0.6.0] / 2023-08-15
 ### 🚀 New features

--- a/src/Candoumbe.Pipelines/Components/GitHub/IGitFlowWithPullRequest.cs
+++ b/src/Candoumbe.Pipelines/Components/GitHub/IGitFlowWithPullRequest.cs
@@ -56,7 +56,7 @@ public interface IGitFlowWithPullRequest : IGitFlow, IPullRequest
         };
 
         Information("Creating {PullRequestName} for {Repository}", title, repositoryName);
-        string token = Token ?? PromptForInput("Token (leave empty to exit)", string.Empty);
+        string token = GitHubToken ?? PromptForInput("Token (leave empty to exit)", string.Empty);
 
         if (!string.IsNullOrWhiteSpace(token))
         {

--- a/src/Candoumbe.Pipelines/Components/GitHub/IPullRequest.cs
+++ b/src/Candoumbe.Pipelines/Components/GitHub/IPullRequest.cs
@@ -17,13 +17,6 @@ namespace Candoumbe.Pipelines.Components.GitHub
         string Title => TryGetValue(() => Title) ?? GitRepository.Branch;
 
         /// <summary>
-        /// Token that will be used to connect to GitHub
-        /// </summary>
-        [Parameter("Token used to create a pull request")]
-        [Secret]
-        string Token => TryGetValue(() => Token);
-
-        /// <summary>
         /// Description of the pull request
         /// </summary>
         [Parameter("Description of the pull request")]

--- a/src/Candoumbe.Pipelines/Components/IHaveGitVersion.cs
+++ b/src/Candoumbe.Pipelines/Components/IHaveGitVersion.cs
@@ -15,7 +15,7 @@ public interface IHaveGitVersion : INukeBuild
     /// <summary>
     /// The GitVersion tool that can be used to version the project
     /// </summary>
-    [GitVersion(Framework = "net5.0", NoFetch = true)]
+    [GitVersion(Framework = "net5.0")]
     [Required]
     public GitVersion GitVersion => TryGetValue(() => GitVersion);
 


### PR DESCRIPTION
### 🚨 Breaking changes
• Removes Github.IPullRequest.Token property. This property was previously used by GitHub.IGitFlowWithPullRequest and GitHub.IGitFlowWithPullRequest when finishing a feature/coldfix is.
### 🛠️ Fixes
• Removes nofetch option when calling gitversion tool.
### 🧹 Housekeeping
• Add GitHubToken value in parameters.json : this value will be consumed directly to interact with the github repository.

Full changelog at https://github.com/candoumbe/Pipelines/blob/coldfix/remove-nofetch-option-when-calling-gitversion/CHANGELOG.md