### PR TITLE
✨[FEATURE] Add Assets To Github Releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `IDoHotfixWorkflow` component which represents the `hotfix` workflow
 - Added `IDoFeatureWorkflow` component which represents the `feature` workflow
 - Added `IDoColdfixWorkflow` component which represents the `coldfix` workflow
+- `ICreateGithubRelease.Assets` property can be used to specify which artifacts to associate with a Github release ([#103](https://github.com/candoumbe/Pipelines/issues/103))
 
 ### 🚨 Breaking changes
 

--- a/src/Candoumbe.Pipelines/Components/GitHub/ICreateGithubRelease.cs
+++ b/src/Candoumbe.Pipelines/Components/GitHub/ICreateGithubRelease.cs
@@ -5,8 +5,10 @@ using Nuke.Common;
 using Nuke.Common.Git;
 using Nuke.Common.IO;
 using Nuke.Common.Tools.GitHub;
-
+using Octokit;
+using System.Buffers;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 
 using static Nuke.Common.ChangeLog.ChangelogTasks;
@@ -41,9 +43,9 @@ public interface ICreateGithubRelease : IHaveGitHubRepository, IHaveChangeLog, I
         {
             string repositoryName = GitRepository.GetGitHubName();
             Information("Creating a new release for {Repository}", repositoryName);
-            Octokit.GitHubClient gitHubClient = new(new Octokit.ProductHeaderValue(repositoryName))
+            GitHubClient gitHubClient = new(new ProductHeaderValue(repositoryName))
             {
-                Credentials = new Octokit.Credentials(GitHubToken)
+                Credentials = new Credentials(GitHubToken)
             };
 
             string repositoryOwner = GitRepository.GetGitHubOwner();
@@ -53,16 +55,26 @@ public interface ICreateGithubRelease : IHaveGitHubRepository, IHaveChangeLog, I
             if (!releases.AtLeastOnce(release => release.Name == MajorMinorPatchVersion))
             {
                 string[] releaseNotes = ExtractChangelogSectionNotes(ChangeLogFile, MajorMinorPatchVersion).Select(line => $"{line}\n").ToArray();
-                Octokit.NewRelease newRelease = new(MajorMinorPatchVersion)
+                NewRelease newRelease = new(MajorMinorPatchVersion)
                 {
                     TargetCommitish = GitRepository.Commit,
                     Body = string.Join("- ", releaseNotes),
                     Name = MajorMinorPatchVersion,
                 };
 
-                Octokit.Release release = await gitHubClient.Repository.Release.Create(repositoryOwner, repositoryName, newRelease)
+                Release release = await gitHubClient.Repository.Release.Create(repositoryOwner, repositoryName, newRelease)
                                                                                .ConfigureAwait(false);
+                await Assets.ForEachAsync(async asset =>
+                {
+                    ReleaseAssetUpload assetToUpload = new ReleaseAssetUpload
+                    {
+                        ContentType = ContentType.File.ToString(),
+                        FileName = asset.ToFileInfo().Name,
+                        RawData = new MemoryStream(File.ReadAllBytes(asset))
+                    };
 
+                    await gitHubClient.Repository.Release.UploadAsset(release, assetToUpload);
+                });
                 Information($"Github release {release.TagName} created successfully");
             }
             else


### PR DESCRIPTION
### 🚀 New features
• Added IDoHotfixWorkflow component which represents the hotfix workflow
• Added IDoFeatureWorkflow component which represents the feature workflow
• Added IDoColdfixWorkflow component which represents the coldfix workflow
• ICreateGithubRelease.Assets property can be used to specify which artifacts to associate with a Github release ([#103](https://github.com/candoumbe/Pipelines/issues/103))
### 🚨 Breaking changes
• Removed Github.IPullRequest.Token property. This property was previously used by GitHub.IGitFlowWithPullRequest and GitHub.IGitFlowWithPullRequest when finishing a feature/coldfix is.
### 🛠️ Fixes
• Removed nofetch option when calling gitversion tool.
### 🧹 Housekeeping
• Added GitHubToken value in parameters.local.json : this value will be consumed directly to interact with the github repository.
• IGitflow%2C IGithubflow components extends IDoHotfixWorkflow component
• IGitflow%2C IGithubflow components extends IDoHotfixWorkflow component
• Added NugetApi valuen in parameters.local.json to interact directly with NuGet from local environment

Full changelog at https://github.com/candoumbe/Pipelines/blob/feature/add-assets-to-github-releases/CHANGELOG.md

Resolves #103