### PR TITLE
✨ Refactor components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### 🚨 Breaking changes
 
 - Removed `Github.IPullRequest.Token` property. This property was previously used by `GitHub.IGitFlowWithPullRequest` and `GitHub.IGitFlowWithPullRequest` when finishing a feature/coldfix is.
+- Refactored `IWorkflow` component and removed inheritance from `IHaveMainBranch` component
 
 ### 🛠️ Fixes
 
-- Removed `nofetch` option when calling `gitversion` tool.
+- Removed `nofetch` option (when calling `gitversion` tool) in order to compute semver version number more accurately ([#96](https://github.com/candoumbe/Pipelines/issues/96)).
 
 ### 🧹 Housekeeping
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Removed `Github.IPullRequest.Token` property. This property was previously used by `GitHub.IGitFlowWithPullRequest` and `GitHub.IGitFlowWithPullRequest` when finishing a feature/coldfix is.
 - Refactored `IWorkflow` component and removed inheritance from `IHaveMainBranch` component
+- Refactored `ICompile` component to no longer extend `IRestore` component
+- Refactored `IPack` component to no longer extend `ICompile` component
 
 ### 🛠️ Fixes
 

--- a/README.md
+++ b/README.md
@@ -95,9 +95,9 @@ In the example above, the build pipeline benefits from the [ICompile] component 
 
 #### `Candoumbe.Pipelines.Components.Workflows`
 
-Contains components related to branching strategies and providing tools that can help normalize how teams works in.
+This workspace contains components related to branching strategies and providing tools that can help normalize how teams works.
 
-[IGitFlow] and [IGitHubFlow] are two components that helps handle branching strategy locally.
+[IGitFlow] and [IGitHubFlow] are two main components that helps handle branching strategy locally.
 
 Some components are used to set the workflow to use throughout a repository and streamline the work of a developer and a team.
 
@@ -105,20 +105,20 @@ Some components are used to set the workflow to use throughout a repository and 
 
 ```mermaid
 %%{init: {"flowchart": {"htmlLabels": false}} }%%
-flowchart LR
+flowchart
     A((start)) --> B[["./build feature"]]
     A -->O[["./build hotfix"]]
     O --> P{is on 'hotfix' branch ?}
     P -- yes --> finish-hotfix
     P -- no --> Q{{computes semver}}
-    Q --> R{{creates 'hotfix/semver' branch}}
+    Q --> R{{creates 'hotfix/<semver>' branch}}
     R --> S[work on your hotfix]
     S --> T{Are you done}
     T -- yes --> O
     T -- not yet --> S
     B --> C{is on 'feature/*' branch ?}
-    C -- no --> D[Creates a new feature/* branch]
     C -- yes --> finish-feature
+    C -- no --> D[Creates a new feature/* branch]
     D --> E[Work on your feature]
     E --> F{Are you done ?}
     F --yes --> B
@@ -180,7 +180,7 @@ the appropriate command to finish your release.
 
 ```mermaid
 %%{init: {"flowchart": {"htmlLabels": false}} }%%
-flowchart LR
+flowchart
     A((start)) --> B["./build release"]
     B --> C{is on 'release/*' branch ?}
     C -- no --> create-branch

--- a/build/Pipeline.cs
+++ b/build/Pipeline.cs
@@ -114,6 +114,9 @@ public class Pipeline : NukeBuild,
     ///<inheritdoc/>
     IEnumerable<AbsolutePath> IPack.PackableProjects => SourceDirectory.GlobFiles("**/*.csproj");
 
+    ///<inheritdoc/>
+    IEnumerable<AbsolutePath> ICreateGithubRelease.Assets => this.Get<IPack>().OutputDirectory.GlobFiles("**/*.nupkg;**/*.snupkg");
+
 
     ///<inheritdoc/>
     IEnumerable<PushNugetPackageConfiguration> IPushNugetPackages.PublishConfigurations => new PushNugetPackageConfiguration[]

--- a/src/Candoumbe.Pipelines/Components/Docker/IBuildDockerImage.cs
+++ b/src/Candoumbe.Pipelines/Components/Docker/IBuildDockerImage.cs
@@ -13,7 +13,7 @@ namespace Candoumbe.Pipelines.Components.Docker;
 /// <summary>
 /// Marks a pipeline that can compile a <see cref="IHaveSolution.Solution"/>
 /// </summary>
-public interface IBuildDockerImage : IHaveConfiguration
+public interface IBuildDockerImage : INukeBuild
 {
     /// <summary>
     /// Gets the docker files to build

--- a/src/Candoumbe.Pipelines/Components/GitHub/ICreateGithubRelease.cs
+++ b/src/Candoumbe.Pipelines/Components/GitHub/ICreateGithubRelease.cs
@@ -22,7 +22,7 @@ namespace Candoumbe.Pipelines.Components.GitHub;
 public interface ICreateGithubRelease : IHaveGitHubRepository, IHaveChangeLog, IHaveGitVersion
 {
     /// <summary>
-    /// Collection of assets to add to the published release.
+    /// Collection of assets/files to add to the published release.
     /// </summary>
     /// <remarks>
     /// Files will be zipped and added to the release
@@ -66,14 +66,17 @@ public interface ICreateGithubRelease : IHaveGitHubRepository, IHaveChangeLog, I
                                                                                .ConfigureAwait(false);
                 await Assets.ForEachAsync(async asset =>
                 {
-                    ReleaseAssetUpload assetToUpload = new ReleaseAssetUpload
+                    if (asset.Exists())
                     {
-                        ContentType = ContentType.File.ToString(),
-                        FileName = asset.ToFileInfo().Name,
-                        RawData = new MemoryStream(File.ReadAllBytes(asset))
-                    };
+                        ReleaseAssetUpload assetToUpload = new ReleaseAssetUpload
+                        {
+                            ContentType = ContentType.File.ToString(),
+                            FileName = asset.ToFileInfo().Name,
+                            RawData = new MemoryStream(File.ReadAllBytes(asset))
+                        };
 
-                    await gitHubClient.Repository.Release.UploadAsset(release, assetToUpload);
+                        await gitHubClient.Repository.Release.UploadAsset(release, assetToUpload);
+                    }
                 });
                 Information($"Github release {release.TagName} created successfully");
             }

--- a/src/Candoumbe.Pipelines/Components/ICompile.cs
+++ b/src/Candoumbe.Pipelines/Components/ICompile.cs
@@ -15,14 +15,14 @@ namespace Candoumbe.Pipelines.Components;
 /// <summary>
 /// Marks a pipeline that can compile a <see cref="IHaveSolution.Solution"/>
 /// </summary>
-public interface ICompile : IRestore, IHaveConfiguration
+public interface ICompile : IHaveSolution, IHaveConfiguration
 {
     /// <summary>
     /// Compiles the specified
     /// </summary>
     public Target Compile => _ => _
         .Description($"Compiles {Solution}")
-        .DependsOn<IRestore>()
+        .TryDependsOn<IRestore>()
         .Executes(() =>
         {
             Information("Compiling {Solution}", Solution);
@@ -40,7 +40,8 @@ public interface ICompile : IRestore, IHaveConfiguration
     /// Default compilation settings
     /// </summary>
     public sealed Configure<DotNetBuildSettings> CompileSettingsBase => _ => _
-                .SetNoRestore(SucceededTargets.Contains(Restore) || SkippedTargets.Contains(Restore))
+                .WhenNotNull(this.As<IRestore>(),
+                             (_, restore) => _.SetNoRestore(SucceededTargets.Contains(restore.Restore) || SkippedTargets.Contains(restore.Restore)))
                 .SetProjectFile(Solution)
                 .SetConfiguration(Configuration)
                 .SetContinuousIntegrationBuild(IsServerBuild)

--- a/src/Candoumbe.Pipelines/Components/IRestore.cs
+++ b/src/Candoumbe.Pipelines/Components/IRestore.cs
@@ -12,7 +12,7 @@ namespace Candoumbe.Pipelines.Components;
 public interface IRestore : INukeBuild, IHaveSolution
 {
     /// <summary>
-    /// Runs "dotnet restore"
+    /// Restore dotnet project dependency
     /// </summary>
     public Target Restore => _ => _
         .TryDependsOn<IClean>(x => x.Clean)

--- a/src/Candoumbe.Pipelines/Components/Workflows/IDoHotfixWorkflow.cs
+++ b/src/Candoumbe.Pipelines/Components/Workflows/IDoHotfixWorkflow.cs
@@ -14,7 +14,7 @@ namespace Candoumbe.Pipelines.Components.Workflows;
 /// It provides properties and a target for managing hotfix workflows, including starting a new hotfix branch and merging it back to the main branch.
 /// </para>
 /// </summary>
-public interface IDoHotfixWorkflow : IWorkflow
+public interface IDoHotfixWorkflow : IWorkflow, IHaveMainBranch
 {
     /// <summary>
     /// Gets the prefix used to name hotfix branches.

--- a/src/Candoumbe.Pipelines/Components/Workflows/IGitFlow.cs
+++ b/src/Candoumbe.Pipelines/Components/Workflows/IGitFlow.cs
@@ -2,13 +2,8 @@
 
 using Nuke.Common;
 using Nuke.Common.Git;
-using Nuke.Common.Tools.GitVersion;
-
-using System;
 using System.Threading.Tasks;
-using JetBrains.Annotations;
 using static Nuke.Common.Tools.Git.GitTasks;
-using static Serilog.Log;
 
 namespace Candoumbe.Pipelines.Components;
 
@@ -30,7 +25,6 @@ public interface IGitFlow : IDoHotfixWorkflow, IDoColdfixWorkflow, IHaveDevelopB
     /// </summary>
     public string ReleaseBranchPrefix => "release";
 
-
     ///<inheritdoc/>
     string IDoFeatureWorkflow.FeatureBranchSourceName => IHaveDevelopBranch.DevelopBranchName;
 
@@ -51,7 +45,6 @@ public interface IGitFlow : IDoHotfixWorkflow, IDoColdfixWorkflow, IHaveDevelopB
         .Requires(() => !GitRepository.IsOnReleaseBranch() || GitHasCleanWorkingCopy())
         .Executes(async () =>
         {
-
             if (!GitRepository.IsOnReleaseBranch())
             {
                 string majorMinorPatchVersion = Major
@@ -65,14 +58,14 @@ public interface IGitFlow : IDoHotfixWorkflow, IDoColdfixWorkflow, IHaveDevelopB
                 await FinishRelease();
             }
         });
-    
+
     /// <summary>
-    /// Merges a <see cref="IWorkflow.ColdfixBranchPrefix"/> back to <see cref="IHaveDevelopBranch.DevelopBranchName"/> branch
+    /// Merges a <see cref="IDoColdfixWorkflow.ColdfixBranchPrefix"/> back to <see cref="IHaveDevelopBranch.DevelopBranchName"/> branch
     /// </summary>
     async ValueTask IDoColdfixWorkflow.FinishColdfix() => await FinishFeature();
 
     /// <summary>
-    /// Merges the current <see cref="ReleaseBranch"/> or <see cref="IWorkflow.HotfixBranchPrefix"/> branch back to <see cref="IHaveMainBranch.MainBranchName"/>.
+    /// Merges the current <see cref="ReleaseBranch"/> or <see cref="IDoHotfixWorkflow.HotfixBranchPrefix"/> branch back to <see cref="IHaveMainBranch.MainBranchName"/>.
     /// </summary>
     ValueTask IDoHotfixWorkflow.FinishHotfix()
     {

--- a/src/Candoumbe.Pipelines/Components/Workflows/IGitFlow.cs
+++ b/src/Candoumbe.Pipelines/Components/Workflows/IGitFlow.cs
@@ -65,7 +65,7 @@ public interface IGitFlow : IDoHotfixWorkflow, IDoColdfixWorkflow, IHaveDevelopB
     async ValueTask IDoColdfixWorkflow.FinishColdfix() => await FinishFeature();
 
     /// <summary>
-    /// Merges the current <see cref="ReleaseBranch"/> or <see cref="IDoHotfixWorkflow.HotfixBranchPrefix"/> branch back to <see cref="IHaveMainBranch.MainBranchName"/>.
+    /// Merges the current hotfix branch back to <see cref="IHaveMainBranch.MainBranchName"/>.
     /// </summary>
     ValueTask IDoHotfixWorkflow.FinishHotfix()
     {

--- a/src/Candoumbe.Pipelines/Components/Workflows/IGitFlow.cs
+++ b/src/Candoumbe.Pipelines/Components/Workflows/IGitFlow.cs
@@ -11,7 +11,7 @@ namespace Candoumbe.Pipelines.Components;
 /// Marks a build as supporting the <see href="https://datasift.github.io/gitflow/IntroducingGitFlow.html">git flow</see> workflow.
 /// </summary>
 /// <remarks>
-/// This interface will provide several ready to use targets to effectively manages this workflow even when the underlying "git" command does not support the gitflow verbs.
+/// This interface will provide several ready to use targets to effectively manages this workflow even when the underlying "git" command does not support gitflow verbs.
 /// </remarks>
 public interface IGitFlow : IDoHotfixWorkflow, IDoColdfixWorkflow, IHaveDevelopBranch
 {
@@ -26,7 +26,7 @@ public interface IGitFlow : IDoHotfixWorkflow, IDoColdfixWorkflow, IHaveDevelopB
     public string ReleaseBranchPrefix => "release";
 
     ///<inheritdoc/>
-    string IDoFeatureWorkflow.FeatureBranchSourceName => IHaveDevelopBranch.DevelopBranchName;
+    string IDoFeatureWorkflow.FeatureBranchSourceName => DevelopBranchName;
 
     ///<inheritdoc/>
     string IDoHotfixWorkflow.HotfixBranchSourceName => MainBranchName;

--- a/src/Candoumbe.Pipelines/Components/Workflows/IWorkflow.cs
+++ b/src/Candoumbe.Pipelines/Components/Workflows/IWorkflow.cs
@@ -15,7 +15,7 @@ namespace Candoumbe.Pipelines.Components.Workflows;
 /// <summary>
 /// Marker interface for git repository that support a specific workflow
 /// </summary>
-public interface IWorkflow : IHaveGitRepository, IHaveMainBranch, IHaveGitVersion, IHaveChangeLog
+public interface IWorkflow : IHaveGitRepository, IHaveGitVersion, IHaveChangeLog
 {
     /// <summary>
     /// Indicates if any changes should be stashed automatically prior to switching branch (Default : true


### PR DESCRIPTION
### 🚀 New features
• Added IDoHotfixWorkflow component which represents the hotfix workflow
• Added IDoFeatureWorkflow component which represents the feature workflow
• Added IDoColdfixWorkflow component which represents the coldfix workflow
• ICreateGithubRelease.Assets property can be used to specify which artifacts to associate with a Github release ([#103](https://github.com/candoumbe/Pipelines/issues/103))
### 🚨 Breaking changes
• Removed Github.IPullRequest.Token property. This property was previously used by GitHub.IGitFlowWithPullRequest and GitHub.IGitFlowWithPullRequest when finishing a feature/coldfix is.
• Refactored IWorkflow component and removed inheritance from IHaveMainBranch component
• Refactored ICompile component to no longer extend IRestore component
• Refactored IPack component to no longer extend ICompile component
### 🛠️ Fixes
• Removed nofetch option (when calling gitversion tool) in order to compute semver version number more accurately ([#96](https://github.com/candoumbe/Pipelines/issues/96)).
### 🧹 Housekeeping
• Added GitHubToken value in parameters.local.json : this value will be consumed directly to interact with the github repository.
• IGitflow%2C IGithubflow components extends IDoHotfixWorkflow component
• IGitflow%2C IGithubflow components extends IDoHotfixWorkflow component
• Added NugetApi valuen in parameters.local.json to interact directly with NuGet from local environment

Full changelog at https://github.com/candoumbe/Pipelines/blob/feature/refactor-components/CHANGELOG.md

Resolves #103, #96