### PR TITLE
✨ Specify Config File To Use For Running Mutation Tests At Project Level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Refactored `IWorkflow` component and removed inheritance from `IHaveMainBranch` component
 - Refactored `ICompile` component to no longer extend `IRestore` component
 - Refactored `IPack` component to no longer extend `ICompile` component
+- Refactored `IMutationTest.MutationTestsProjects` type from `(Project SourceProject, IEnumerable<Project> TestsProjects)` to `IEnumerable<MutationTestProjectConfiguration>`:
+this new type allows to specify the path to the configuration file to use during each mutation test run.
+- `IMutationTest` component no longer implements `IUnitTest` but only `IHaveTests`
 
 ### 🛠️ Fixes
 
@@ -26,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### 🧹 Housekeeping
 
+- Refactoring of `IMutationTest` component to improve maintenability : the way CLI options required by Stryker are computed is now centralized.
 - Added `GitHubToken` value in `parameters.local.json` : this value will be consumed directly to interact with the github repository.
 - `IGitflow`, `IGithubflow` components extends `IDoHotfixWorkflow` component
 - `IGitflow`, `IGithubflow` components extends `IDoHotfixWorkflow` component

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ this new type allows to specify the path to the configuration file to use during
 - `IGitflow`, `IGithubflow` components extends `IDoHotfixWorkflow` component
 - `IGitflow`, `IGithubflow` components extends `IDoHotfixWorkflow` component
 - Added `NugetApi` valuen in `parameters.local.json` to interact directly with NuGet from local environment
+- Added documentation for `IMutationTest` classes
 
 ## [0.6.1] / 2023-08-31
 ### 🔧 Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `IDoFeatureWorkflow` component which represents the `feature` workflow
 - Added `IDoColdfixWorkflow` component which represents the `coldfix` workflow
 - `ICreateGithubRelease.Assets` property can be used to specify which artifacts to associate with a Github release ([#103](https://github.com/candoumbe/Pipelines/issues/103))
+- `IMutationTest` component can send `--config-file` option to Stryker CLI ([#90](https://github.com/candoumbe/Pipelines/issues/90))
 
 ### 🚨 Breaking changes
 

--- a/src/Candoumbe.Pipelines/Components/IMutationTest.cs
+++ b/src/Candoumbe.Pipelines/Components/IMutationTest.cs
@@ -91,9 +91,7 @@ public interface IMutationTest : IHaveTests
                 MutationTestsProjects.ForEach(mutationProject => RunMutationTestsForTheProject(mutationProject, framework));
             }
 
-            /// <summary>
-            /// Run mutation tests for the specified project using the specified arguments
-            /// </summary>
+            // Run mutation tests for the specified project using the specified arguments
             void RunMutationTestsForTheProject(MutationProjectConfiguration mutationProject, string framework)
             {
                 (Project sourceProject, IEnumerable<Project> testsProjects, AbsolutePath configFile) = mutationProject;
@@ -117,7 +115,6 @@ public interface IMutationTest : IHaveTests
                 strykerArgs = strykerArgs.Concatenate(args);
 
                 strykerArgs.Add(@"--project {value}", sourceProject.Name);
-
 
                 testsProjects.ForEach(project =>
                 {
@@ -262,8 +259,6 @@ file record MutationTestRunConfiguration
     public string[] Frameworks { get; init; }
 
     public StrykerProjectInfo ProjectInfo { get; init; }
-
-
 }
 
 file record StrykerProjectInfo

--- a/src/Candoumbe.Pipelines/Components/IMutationTest.cs
+++ b/src/Candoumbe.Pipelines/Components/IMutationTest.cs
@@ -4,6 +4,7 @@ using Nuke.Common;
 using Nuke.Common.IO;
 using Nuke.Common.ProjectModel;
 using Nuke.Common.Tooling;
+using Nuke.Common.Utilities;
 
 using System;
 using System.Collections.Generic;
@@ -11,7 +12,6 @@ using System.Linq;
 
 using static Nuke.Common.Tools.DotNet.DotNetTasks;
 using static Serilog.Log;
-
 namespace Candoumbe.Pipelines.Components;
 
 /// <summary>
@@ -22,7 +22,7 @@ namespace Candoumbe.Pipelines.Components;
 /// Simply adds <c>&lt;PackageReference Include="dotnet-stryker" Version="" ExcludeAssets="all" &gt;</c> to your build project file
 /// </remarks>
 [NuGetPackageRequirement("dotnet-stryker")]
-public interface IMutationTest : IUnitTest
+public interface IMutationTest : IHaveTests
 {
     /// <summary>
     /// Name of the property set when <see href="SourceLink">SourceLink</see> is enabled on a projet.
@@ -46,7 +46,7 @@ public interface IMutationTest : IUnitTest
     /// <remarks>
     /// The source project has
     /// </remarks>
-    IEnumerable<(Project SourceProject, IEnumerable<Project> TestProjects)> MutationTestsProjects { get; }
+    IEnumerable<MutationProjectConfiguration> MutationTestsProjects { get; }
 
     /// <summary>
     /// Executes mutation tests for the specified <see cref="MutationTestsProjects"/>.
@@ -56,146 +56,141 @@ public interface IMutationTest : IUnitTest
         .Description("Runs mutation tests using Stryker tool")
         .TryDependsOn<IClean>(x => x.Clean)
         .TryBefore<IPack>()
-        .DependsOn(Compile)
+        .TryDependsOn<ICompile>(x => x.Compile)
         .Produces(MutationTestResultDirectory / "*")
         .Executes(() =>
         {
-            int mutationProjectCount = 0;
-
-            // List of frameworks that source project are tested against
-            string[] frameworks = MutationTestsProjects.Select(csprojAndTest => csprojAndTest.TestProjects)
-                                                       .SelectMany(projects => projects)
-                                                       .Select(csproj => csproj.GetTargetFrameworks())
-                                                       .SelectMany(x => x)
-                                                       .Select(targetFramework => targetFramework.ToLower().Trim())
-                                                       .AsParallel()
-                                                       .Distinct()
-                                                       .ToArray();
-
+            // List of frameworks that source projects are tested against
+            IReadOnlyCollection<string> frameworks = MutationTestsProjects.Select(csprojAndTest => csprojAndTest.TestProjects)
+                                                                          .SelectMany(projects => projects)
+                                                                          .Select(csproj => csproj.GetTargetFrameworks())
+                                                                          .SelectMany(x => x)
+                                                                          .Select(targetFramework => targetFramework.Trim())
+                                                                          .AsParallel()
+                                                                          .Distinct(StringComparer.OrdinalIgnoreCase)
+                                                                          .ToArray();
 
             if (frameworks.AtLeast(2))
             {
-                MutationTestsProjects.ForEach(tuple =>
+                // We iterate over each test project
+                MutationTestsProjects.ForEach(mutationProject =>
                 {
-                    mutationProjectCount++;
-                    (Project sourceProject, IEnumerable<Project> testsProjects) = tuple;
-                    AbsolutePath mutationTestOutputDirectory = MutationTestResultDirectory / sourceProject.Name;
+                    // We retrieve the current set of frameworks the current test project are tested against
+                    IReadOnlyCollection<string> testedFrameworks = mutationProject.TestProjects.Select(csproj => csproj.GetTargetFrameworks())
+                                                                                               .SelectMany(frameworks => frameworks)
+                                                                                               .Distinct(StringComparer.OrdinalIgnoreCase)
+                                                                                               .ToArray();
 
-                    IReadOnlyCollection<string> testedFrameworks = testsProjects.Select(csproj => csproj.GetTargetFrameworks())
-                                                                                   .SelectMany(x => x)
-                                                                                   .Distinct()
-                                                                                   .ToArray();
-                    Arguments args;
-                    if (testedFrameworks.AtLeast(2))
-                    {
-                        testedFrameworks.ForEach(framework =>
-                        {
-                            args = new();
-                            args.Apply(StrykerArgumentsSettingsBase)
-                                .Apply(StrykerArgumentsSettings);
-
-                            args.Add("--target-framework {value}", framework)
-                                .Add("--output {value}", mutationTestOutputDirectory / framework);
-
-                            RunMutationTestsForTheProject(sourceProject, testsProjects, args);
-                        });
-                    }
-                    else
-                    {
-                        args = new();
-                        string framework = testedFrameworks.Single();
-                        args.Add("--target-framework {value}", framework)
-                            .Add("--output {value}", mutationTestOutputDirectory / framework);
-
-                        RunMutationTestsForTheProject(sourceProject, testsProjects, args);
-                    }
+                    testedFrameworks.ForEach(framework => RunMutationTestsForTheProject(mutationProject, framework));
                 });
             }
             else
             {
+                string framework = frameworks.Single();
+
+                MutationTestsProjects.ForEach(mutationProject => RunMutationTestsForTheProject(mutationProject, framework));
+            }
+
+            /// <summary>
+            /// Run mutation tests for the specified project using the specified arguments
+            /// </summary>
+            void RunMutationTestsForTheProject(MutationProjectConfiguration mutationProject, string framework)
+            {
+                (Project sourceProject, IEnumerable<Project> testsProjects, AbsolutePath configFile) = mutationProject;
+
+                Verbose("{ProjetName} will run mutation tests for the following frameworks : {@Frameworks}", sourceProject.Name, sourceProject.GetTargetFrameworks());
+
+                MutationTestRunConfiguration mutationTestRunConfiguration = (configFile?.FileExists() is true
+                                ? configFile.ReadJson<MutationTestRunConfiguration>()
+                                : null);
+
                 Arguments args = new();
-                args.Apply(StrykerArgumentsSettingsBase)
-                    .Apply(StrykerArgumentsSettings);
+                args = args.Apply(StrykerArgumentsSettingsBase)
+                           .Apply(StrykerArgumentsSettings);
 
-                args.Add("--target-framework {value}", frameworks.Single());
+                args.Add("--target-framework {value}", framework)
+                    .Add("--output {value}", MutationTestResultDirectory / sourceProject.Name / framework);
 
-                MutationTestsProjects.ForEach(tuple =>
+                Arguments strykerArgs = new();
+                strykerArgs = strykerArgs.Add("stryker");
+
+                strykerArgs = strykerArgs.Concatenate(args);
+
+                strykerArgs.Add(@"--project {value}", sourceProject.Name);
+
+
+                testsProjects.ForEach(project =>
                 {
-                    mutationProjectCount++;
-                    args = args.Add("--output {value}", MutationTestResultDirectory / tuple.SourceProject.Name);
-                    RunMutationTestsForTheProject(tuple.SourceProject, tuple.TestProjects, args);
+                    strykerArgs = strykerArgs.Add(@"--test-project {value}", project.Path);
                 });
+
+                switch (this)
+                {
+                    case IGitFlow gitFlow when gitFlow.GitRepository is { } gitflowRepository:
+                        {
+                            strykerArgs = strykerArgs.Add("--version {value}", gitflowRepository.Commit ?? gitflowRepository.Branch);
+                            switch (gitflowRepository.Branch)
+                            {
+                                case string branchName when string.Equals(branchName, IGitFlow.DevelopBranchName, StringComparison.InvariantCultureIgnoreCase):
+                                    {
+                                        // we are in git flow so we can compare develop with main branch
+                                        strykerArgs = strykerArgs.Add("--with-baseline:{value}", IGitFlow.MainBranchName);
+                                    }
+                                    break;
+                                case string branchName when branchName.Like($"{gitFlow.FeatureBranchPrefix}/*", true):
+                                    {
+                                        strykerArgs = strykerArgs.Add("--with-baseline:{value}", gitFlow.FeatureBranchSourceName);
+                                    }
+                                    break;
+                                case string branchName when branchName.Like($"{gitFlow.ColdfixBranchPrefix}/*", true):
+                                    {
+                                        strykerArgs = strykerArgs.Add("--with-baseline:{value}", gitFlow.ColdfixBranchSourceName);
+                                    }
+                                    break;
+                                default:
+                                    {
+                                        // By default we try to compare the current commit with the previous one (if any).
+                                        if (gitflowRepository.Head is string head)
+                                        {
+                                            strykerArgs = strykerArgs.Add("--with-baseline:{value}", head);
+                                        }
+                                    }
+                                    break;
+                            }
+
+                            break;
+                        }
+
+                    case IGitHubFlow gitHubFlow when gitHubFlow.GitRepository is { } githubFlowRepository:
+                        {
+                            strykerArgs = strykerArgs.Add("--version {value}", githubFlowRepository.Commit ?? githubFlowRepository.Branch);
+                            if (githubFlowRepository.Branch is { Length: > 0 } branchName && !string.Equals(branchName, IGitHubFlow.MainBranchName, StringComparison.InvariantCultureIgnoreCase))
+                            {
+                                strykerArgs = strykerArgs.Add("--with-baseline:{0}", IGitHubFlow.MainBranchName);
+                            }
+
+                            break;
+                        }
+
+                    default:
+                        if (!sourceProject.IsSourceLinkEnabled())
+                        {
+                            if (this is IHaveGitVersion gitVersion)
+                            {
+                                strykerArgs = strykerArgs.Add("--version {value}", gitVersion.MajorMinorPatchVersion);
+                            }
+                            else if (this is IHaveGitRepository gitRepository)
+                            {
+                                strykerArgs = strykerArgs.Add("--version {value}", gitRepository.GitRepository?.Commit ?? gitRepository?.GitRepository?.Branch);
+                            }
+                        }
+
+                        break;
+                }
+
+                DotNet(strykerArgs.RenderForExecution(), workingDirectory: sourceProject.Path.Parent);
             }
         });
-
-    /// <summary>
-    /// Run mutation tests for the specified project using the specified arguments
-    /// </summary>
-    private void RunMutationTestsForTheProject(Project sourceProject, IEnumerable<Project> testsProjects, Arguments args)
-    {
-        Verbose("{ProjetName} will run mutation tests for the following frameworks : {@Frameworks}", sourceProject.Name, sourceProject.GetTargetFrameworks());
-
-        Arguments strykerArgs = new();
-        strykerArgs = strykerArgs.Add("stryker");
-        strykerArgs = strykerArgs.Concatenate(args);
-
-        strykerArgs.Add(@"--project {value}", sourceProject.Name);
-
-        testsProjects.ForEach(project =>
-        {
-            strykerArgs = strykerArgs.Add(@"--test-project {value}", project.Path);
-        });
-
-        if (this is IGitFlow gitFlow && gitFlow.GitRepository is { } gitflowRepository)
-        {
-            strykerArgs = strykerArgs.Add("--version {value}", gitflowRepository.Commit ?? gitflowRepository.Branch);
-            switch (gitflowRepository.Branch)
-            {
-                case string branchName when string.Equals(branchName, IGitFlow.DevelopBranchName, StringComparison.InvariantCultureIgnoreCase):
-                    {
-                        // we are in git flow so comparison we can compare develop against main branch
-                        strykerArgs = strykerArgs.Add("--with-baseline:{value}", IGitFlow.MainBranchName);
-
-                    }
-                    break;
-                case string branchName when branchName.Like($"{gitFlow.FeatureBranchPrefix}/*", true):
-                    {
-                        strykerArgs = strykerArgs.Add("--with-baseline:{value}", gitFlow.FeatureBranchSourceName);
-                    }
-                    break;
-                case string branchName when branchName.Like($"{gitFlow.ColdfixBranchPrefix}/*", true):
-                    {
-                        strykerArgs = strykerArgs.Add("--with-baseline:{value}", gitFlow.ColdfixBranchSourceName);
-                    }
-                    break;
-                default:
-                    break;
-            }
-        }
-        else if (this is IGitHubFlow gitHubFlow && gitHubFlow.GitRepository is { } githubFlowRepository)
-        {
-            strykerArgs = strykerArgs.Add("--version {value}", githubFlowRepository.Commit ?? githubFlowRepository.Branch);
-            if (githubFlowRepository.Branch is { Length: > 0 } branchName && !string.Equals(branchName, IGitHubFlow.MainBranchName, StringComparison.InvariantCultureIgnoreCase))
-            {
-                strykerArgs = strykerArgs.Add("--with-baseline:{0}", IGitHubFlow.MainBranchName);
-            }
-        }
-        else if (!sourceProject.IsSourceLinkEnabled())
-        {
-            if (this is IHaveGitVersion gitVersion)
-            {
-                strykerArgs = strykerArgs.Add("--version {value}", gitVersion.MajorMinorPatchVersion);
-            }
-            else if (this is IHaveGitRepository gitRepository)
-            {
-                strykerArgs = strykerArgs.Add("--version {value}", gitRepository.GitRepository?.Commit ?? gitRepository?.GitRepository?.Branch);
-            }
-        }
-
-        DotNet(strykerArgs.RenderForExecution(), workingDirectory: sourceProject.Path.Parent);
-
-
-    }
 
     internal Configure<Arguments> StrykerArgumentsSettingsBase => _
         => _
@@ -211,4 +206,69 @@ public interface IMutationTest : IUnitTest
     /// Configures arguments that will be used by when running Stryker tool
     /// </summary>
     Configure<Arguments> StrykerArgumentsSettings => _ => _;
+}
+
+/// <summary>
+/// Wraps information on mutation tests for a specific project.
+/// </summary>
+public record MutationProjectConfiguration
+{
+    /// <summary>
+    /// The project for which mutation tests will be run.
+    /// </summary>
+    public Project SourceProject { get; }
+
+    /// <summary>
+    /// Set
+    /// </summary>
+    public IReadOnlySet<Project> TestProjects { get; }
+
+    /// <summary>
+    /// Path to the JSON configuration file to use when running mutation tests for <see cref="SourceProject"/>
+    /// </summary>
+    public AbsolutePath ConfigurationFile { get; init; }
+
+    /// <summary>
+    /// Builds a new <see cref="MutationProjectConfiguration"/>
+    /// </summary>
+    /// <param name="sourceProject">The project onto which mutation will be performed</param>
+    /// <param name="testProjects">List of projects that will be used to validate mutation performed. These are usually</param>
+    /// <param name="configurationFile">Path to the configuration file that can be used by Stryker when running mutation tests.</param>
+    public MutationProjectConfiguration(Project sourceProject, IEnumerable<Project> testProjects, AbsolutePath configurationFile = default)
+    {
+        SourceProject = sourceProject ?? throw new ArgumentNullException(nameof(sourceProject));
+        TestProjects = testProjects.ToHashSet();
+        ConfigurationFile = configurationFile;
+    }
+
+    ///<inheritdoc/>
+    public void Deconstruct(out Project sourceProject, out IReadOnlySet<Project> testProjects, out AbsolutePath configurationFile)
+    {
+        sourceProject = SourceProject;
+        testProjects = TestProjects;
+        configurationFile = ConfigurationFile;
+    }
+}
+
+file record MutationTestRunConfiguration
+{
+    /// <summary>
+    /// Name of the module under which regroup result of the current mutation test run
+    /// </summary>
+    public string Module { get; init; }
+
+    public string[] TestsProjects { get; init; }
+
+    public string[] Frameworks { get; init; }
+
+    public StrykerProjectInfo ProjectInfo { get; init; }
+
+
+}
+
+file record StrykerProjectInfo
+{
+    public string Module { get; init; }
+
+    public string Version { get; init; }
 }

--- a/src/Candoumbe.Pipelines/Components/IMutationTest.cs
+++ b/src/Candoumbe.Pipelines/Components/IMutationTest.cs
@@ -123,7 +123,7 @@ public interface IMutationTest : IHaveTests
 
                 switch (this)
                 {
-                    case IGitFlow gitFlow when gitFlow.GitRepository is { } gitflowRepository:
+                    case IGitFlow { GitRepository: { } gitflowRepository } gitFlow:
                         {
                             strykerArgs = strykerArgs.Add("--version {value}", gitflowRepository.Commit ?? gitflowRepository.Branch);
                             switch (gitflowRepository.Branch)
@@ -158,7 +158,7 @@ public interface IMutationTest : IHaveTests
                             break;
                         }
 
-                    case IGitHubFlow gitHubFlow when gitHubFlow.GitRepository is { } githubFlowRepository:
+                    case IGitHubFlow { GitRepository: { } githubFlowRepository } gitHubFlow:
                         {
                             strykerArgs = strykerArgs.Add("--version {value}", githubFlowRepository.Commit ?? githubFlowRepository.Branch);
                             if (githubFlowRepository.Branch is { Length: > 0 } branchName && !string.Equals(branchName, IGitHubFlow.MainBranchName, StringComparison.InvariantCultureIgnoreCase))
@@ -216,21 +216,22 @@ public record MutationProjectConfiguration
     public Project SourceProject { get; }
 
     /// <summary>
-    /// Set
+    /// The set of projects used to validate the mutation performed.
     /// </summary>
     public IReadOnlySet<Project> TestProjects { get; }
 
     /// <summary>
-    /// Path to the JSON configuration file to use when running mutation tests for <see cref="SourceProject"/>
+    /// The path to the configuration file used by the mutation testing tool.
     /// </summary>
     public AbsolutePath ConfigurationFile { get; init; }
 
     /// <summary>
-    /// Builds a new <see cref="MutationProjectConfiguration"/>
+    /// Initializes a new instance of the <see cref="MutationProjectConfiguration"/> class.
     /// </summary>
-    /// <param name="sourceProject">The project onto which mutation will be performed</param>
-    /// <param name="testProjects">List of projects that will be used to validate mutation performed. These are usually</param>
-    /// <param name="configurationFile">Path to the configuration file that can be used by Stryker when running mutation tests.</param>
+    /// <param name="sourceProject">The project for which mutation tests will be run.</param>
+    /// <param name="testProjects">The set of projects used to validate the mutation performed.</param>
+    /// <param name="configurationFile">The path to the configuration file used by the mutation testing tool.</param>
+    /// <exception cref="ArgumentNullException">if either <paramref name="sourceProject"/> or <paramref name="testProjects"/> is <see langword="null"/>.</exception>
     public MutationProjectConfiguration(Project sourceProject, IEnumerable<Project> testProjects, AbsolutePath configurationFile = default)
     {
         SourceProject = sourceProject ?? throw new ArgumentNullException(nameof(sourceProject));
@@ -238,7 +239,12 @@ public record MutationProjectConfiguration
         ConfigurationFile = configurationFile;
     }
 
-    ///<inheritdoc/>
+    /// <summary>
+    /// Deconstructs the <see cref="MutationProjectConfiguration"/> into its individual properties.
+    /// </summary>
+    /// <param name="sourceProject">The project for which mutation tests will be run.</param>
+    /// <param name="testProjects">The set of projects used to validate the mutation performed.</param>
+    /// <param name="configurationFile">The path to the configuration file used by the mutation testing tool.</param>
     public void Deconstruct(out Project sourceProject, out IReadOnlySet<Project> testProjects, out AbsolutePath configurationFile)
     {
         sourceProject = SourceProject;
@@ -247,23 +253,71 @@ public record MutationProjectConfiguration
     }
 }
 
-file record MutationTestRunConfiguration
+/// <summary>
+/// Represents the configuration for a mutation test run.
+/// </summary>
+/// <remarks>
+/// The `MutationTestRunConfiguration` class contains information such as the module name, test projects, frameworks, and project info.
+/// </remarks>
+/// <example>
+/// <code>
+/// MutationTestRunConfiguration config = new MutationTestRunConfiguration
+/// {
+///     Module = "MyModule",
+///     TestsProjects = new string[] { "TestProject1", "TestProject2" },
+///     Frameworks = new string[] { "netcoreapp3.1", "net5.0" },
+///     ProjectInfo = new StrykerProjectInfo
+///     {
+///         Module = "MyProject",
+///         Version = "1.0.0"
+///     }
+/// };
+/// </code>
+/// </example>
+public record MutationTestRunConfiguration
 {
     /// <summary>
-    /// Name of the module under which regroup result of the current mutation test run
+    /// Gets or sets the name of the module under which the results of the mutation test run are grouped.
     /// </summary>
     public string Module { get; init; }
 
+    /// <summary>
+    /// Gets or sets the array of test project names that will be used to validate the mutation performed.
+    /// </summary>
     public string[] TestsProjects { get; init; }
 
+    /// <summary>
+    /// Gets or sets the array of target frameworks for the mutation test run.
+    /// </summary>
     public string[] Frameworks { get; init; }
 
+    /// <summary>
+    /// Gets or sets the information about the Stryker project, including the module name and version.
+    /// </summary>
     public StrykerProjectInfo ProjectInfo { get; init; }
 }
 
-file record StrykerProjectInfo
+/// <summary>
+/// Represents information about a Stryker project, including its module and version.
+/// </summary>
+/// <example>
+/// <code>
+/// StrykerProjectInfo projectInfo = new StrykerProjectInfo
+/// {
+///     Module = "MyProject",
+///     Version = "1.0.0"
+/// };
+/// </code>
+/// </example>
+public record StrykerProjectInfo
 {
+    /// <summary>
+    /// Gets or sets the name of the module under which the project is grouped.
+    /// </summary>
     public string Module { get; init; }
 
+    /// <summary>
+    /// Gets or sets the version of the project.
+    /// </summary>
     public string Version { get; init; }
 }

--- a/src/Candoumbe.Pipelines/Components/IMutationTest.cs
+++ b/src/Candoumbe.Pipelines/Components/IMutationTest.cs
@@ -98,10 +98,6 @@ public interface IMutationTest : IHaveTests
 
                 Verbose("{ProjetName} will run mutation tests for the following frameworks : {@Frameworks}", sourceProject.Name, sourceProject.GetTargetFrameworks());
 
-                MutationTestRunConfiguration mutationTestRunConfiguration = (configFile?.FileExists() is true
-                                ? configFile.ReadJson<MutationTestRunConfiguration>()
-                                : null);
-
                 Arguments args = new();
                 args = args.Apply(StrykerArgumentsSettingsBase)
                            .Apply(StrykerArgumentsSettings);
@@ -115,6 +111,11 @@ public interface IMutationTest : IHaveTests
                 strykerArgs = strykerArgs.Concatenate(args);
 
                 strykerArgs.Add(@"--project {value}", sourceProject.Name);
+
+                if (configFile is not null)
+                {
+                    strykerArgs.Add(@"--config-file {value}", configFile);
+                }
 
                 testsProjects.ForEach(project =>
                 {

--- a/src/Candoumbe.Pipelines/Components/IReportCoverage.cs
+++ b/src/Candoumbe.Pipelines/Components/IReportCoverage.cs
@@ -20,7 +20,7 @@ using static Nuke.Common.Tools.ReportGenerator.ReportGeneratorTasks;
 /// This component requires <see href="https://nuget.org/packages/reportgenerator">ReportGenerator tool</see>
 /// </remarks>
 [NuGetPackageRequirement("ReportGenerator")]
-public interface IReportCoverage : IUnitTest
+public interface IReportCoverage : IUnitTest, IRequireNuGetPackage
 {
     /// <summary>
     /// The API key used to push code coverage to CodeCov


### PR DESCRIPTION
### 🚀 New features
• Added IDoHotfixWorkflow component which represents the hotfix workflow
• Added IDoFeatureWorkflow component which represents the feature workflow
• Added IDoColdfixWorkflow component which represents the coldfix workflow
• ICreateGithubRelease.Assets property can be used to specify which artifacts to associate with a Github release ([#103](https://github.com/candoumbe/Pipelines/issues/103))
• IMutationTest component can send --config-file option to Stryker CLI ([#90](https://github.com/candoumbe/Pipelines/issues/90))
### 🚨 Breaking changes
• Removed Github.IPullRequest.Token property. This property was previously used by GitHub.IGitFlowWithPullRequest and GitHub.IGitFlowWithPullRequest when finishing a feature/coldfix is.
• Refactored IWorkflow component and removed inheritance from IHaveMainBranch component
• Refactored ICompile component to no longer extend IRestore component
• Refactored IPack component to no longer extend ICompile component
• Refactored IMutationTest.MutationTestsProjects type from (Project SourceProject%2C IEnumerable<Project> TestsProjects) to IEnumerable<MutationTestProjectConfiguration>:
this new type allows to specify the path to the configuration file to use during each mutation test run.
• IMutationTest component no longer implements IUnitTest but only IHaveTests
### 🛠️ Fixes
• Removed nofetch option (when calling gitversion tool) in order to compute semver version number more accurately ([#96](https://github.com/candoumbe/Pipelines/issues/96)).
### 🧹 Housekeeping
• Refactoring of IMutationTest component to improve maintenability : the way CLI options required by Stryker are computed is now centralized.
• Added GitHubToken value in parameters.local.json : this value will be consumed directly to interact with the github repository.
• IGitflow%2C IGithubflow components extends IDoHotfixWorkflow component
• IGitflow%2C IGithubflow components extends IDoHotfixWorkflow component
• Added NugetApi valuen in parameters.local.json to interact directly with NuGet from local environment
• Added documentation for IMutationTest classes

Full changelog at https://github.com/candoumbe/Pipelines/blob/feature/specify-config-file-to-use-for-running-mutation-tests-at-project-level/CHANGELOG.md

Resolves #90