### PR TITLE
✨ Enable Terminal Logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Enabled `TerminalLogger` ([#138](https://github.com/candoumbe/Pipelines/issues/138))
 
+### 🛠️ Fixes
+- Fixed `Nuke.Common` dependency used when targeting `net6.0`
+
 ## [0.9.0] / 2024-01-25
 ### 🚀 New features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### 🚀 New features
+
+- Enabled `TerminalLogger` ([#138](https://github.com/candoumbe/Pipelines/issues/138))
 
 ## [0.9.0] / 2024-01-25
 ### 🚀 New features

--- a/src/Candoumbe.Pipelines/Candoumbe.Pipelines.csproj
+++ b/src/Candoumbe.Pipelines/Candoumbe.Pipelines.csproj
@@ -2,7 +2,7 @@
 
   <Import Project="../../core.props" />
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <Description>A Stater development kit to script your CI/CD using [Nuke](https://nuke.build).</Description>
     <PackageTags>build, pipeline, ci, workflow</PackageTags>
   </PropertyGroup>

--- a/src/Candoumbe.Pipelines/Candoumbe.Pipelines.csproj
+++ b/src/Candoumbe.Pipelines/Candoumbe.Pipelines.csproj
@@ -7,7 +7,19 @@
     <PackageTags>build, pipeline, ci, workflow</PackageTags>
   </PropertyGroup>
 
+  <Choose>
+      <When Condition="'$(TargetFramework)' == 'net6.0'">
+          <ItemGroup>
+              <PackageReference Include="Nuke.Common" Version="7.0.6" />
+          </ItemGroup>
+      </When>
+      <Otherwise>
+          <ItemGroup>
+              <PackageReference Include="Nuke.Common" Version="8.0.0" />
+          </ItemGroup>
+      </Otherwise>
+  </Choose>
+
   <ItemGroup>
-    <PackageReference Include="Nuke.Common" Version="8.0.0" />
   </ItemGroup>
 </Project>

--- a/src/Candoumbe.Pipelines/Components/ICompile.cs
+++ b/src/Candoumbe.Pipelines/Components/ICompile.cs
@@ -45,6 +45,7 @@ public interface ICompile : IHaveSolution, IHaveConfiguration
                 .SetProjectFile(Solution)
                 .SetConfiguration(Configuration)
                 .SetContinuousIntegrationBuild(IsServerBuild)
+                .SetProcessArgumentConfigurator(args => args.Add("--tl"))
                 .WhenNotNull(this.As<IHaveGitVersion>(),
                              (settings, gitVersion) => settings.SetAssemblyVersion(gitVersion.GitVersion.AssemblySemVer)
                                                                .SetFileVersion(gitVersion.GitVersion.AssemblySemFileVer)


### PR DESCRIPTION
### 🚀 New features
• Enabled TerminalLogger ([#138](https://github.com/candoumbe/Pipelines/issues/138))
### 🛠️ Fixes
• Fixed Nuke.Common dependency used when targeting net6.0

Full changelog at https://github.com/candoumbe/Pipelines/blob/feature/enable-terminal-logger/CHANGELOG.md

Resolves #138