### PR TITLE
🧹 Rename `--quiet` option to `--skip-confirmation`

### DIFF
--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -111,10 +111,6 @@
             "type": "string"
           }
         },
-        "Quiet": {
-          "type": "boolean",
-          "description": "Set to true to not ask any confirmation to the end user (default: false)"
-        },
         "Root": {
           "type": "string",
           "description": "Root directory during build execution"
@@ -138,6 +134,10 @@
               "Restore"
             ]
           }
+        },
+        "SkipConfirmation": {
+          "type": "boolean",
+          "description": "Set to true to not ask any confirmation to the end user (default: false)"
         },
         "Solution": {
           "type": "string",

--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -16,7 +16,7 @@
         },
         "Configuration": {
           "type": "string",
-          "description": "Defines the configuratoin to use when building the application",
+          "description": "Defines the configuration to use when building the application",
           "enum": [
             "Debug",
             "Release"

--- a/.nuke/parameters.local.json
+++ b/.nuke/parameters.local.json
@@ -1,4 +1,4 @@
 {
   "GitHubToken": "v1:rDcK7lT0St3/CdfzkxuYhNWZWoGLJhIHC133qAjgkdaPVMcPfo7yr8Rc8oKHEEPssOrAylXXAMfp/u0pVr8p3OTAT0Va2BJBnpGSKZlg2ubSjFD+uIOzAl3JTo8aajjD",
-  "NugetApiKey": "v1:O4onJUdFCYKibIznM+rL7kn16wdBGof+2fgzACS+tSVm85gMhVY/AD3Ec1HXCppy"
+  "NugetApiKey": "v1:Sb2YkCpSpTtZP7OxoNc+5hQNmvo6/8sppRW+eNMDuBJ3GK2Iy2VpcW+GRjQIGN73"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### 🚀 New features
 
 - Enabled `TerminalLogger` ([#138](https://github.com/candoumbe/Pipelines/issues/138))
-- Added a new `--quiet` option to skip asking confirmations ([#145](https://github.com/candoumbe/Pipelines/issues/145))
+- Added a new `--skip-confirmation` option to skip asking confirmations ([#145](https://github.com/candoumbe/Pipelines/issues/145))
+- Introduced [`EnhancedNukeBuild`] that can be used as drop-in replacement of the `NukeBuild`.
+[`EnhancedNukeBuild`] class adds support for some options to the `NukeBuild` such as the new `--skip-confirmation` option 
+
 
 ### 🛠️ Fixes
 - Fixed `Nuke.Common` dependency used when targeting `net6.0`
@@ -195,6 +198,8 @@ So now `{MutationTestDirectory}/[{framework}]` is now changed to `{MutationTestD
 
 ## [0.1.0] / 2022-10-23
 - Initial release
+
+[`EnhancedNukeBuild`]:./src/Candoumbe.Pipelines/Components/EnhancedNukeBuild.cs
 
 [Unreleased]: https://github.com/candoumbe/Pipelines/compare/0.9.0...HEAD
 [0.9.0]: https://github.com/candoumbe/Pipelines/compare/0.8.0...0.9.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### 🚀 New features
-
 - Enabled `TerminalLogger` ([#138](https://github.com/candoumbe/Pipelines/issues/138))
-- Added a new `--skip-confirmation` option to skip asking confirmations ([#145](https://github.com/candoumbe/Pipelines/issues/145))
+- Added a new `--skip-confirmation` option to skip asking confirmations ([#145](https://github.com/candoumbe/Pipelines/issues/145)).
+This can improve usability in non-interactive environments.
 - Introduced [`EnhancedNukeBuild`] that can be used as drop-in replacement of the `NukeBuild`.
-[`EnhancedNukeBuild`] class adds support for some options to the `NukeBuild` such as the new `--skip-confirmation` option 
-
+[`EnhancedNukeBuild`] class adds support for some options to the `NukeBuild` such as the new `--skip-confirmation` option. 
 
 ### 🛠️ Fixes
 - Fixed `Nuke.Common` dependency used when targeting `net6.0`

--- a/build/Pipeline.cs
+++ b/build/Pipeline.cs
@@ -84,18 +84,12 @@ public class Pipeline : EnhancedNukeBuild,
         this.Get<IHaveArtifacts>().ArtifactsDirectory,
     };
 
-    [CI]
-    public GitHubActions GitHubActions;
-
     [Required]
     [Solution]
     public Solution Solution;
     
     ///<inheritdoc/>
     Solution IHaveSolution.Solution => Solution;
-
-    ///<inheritdoc/>
-    public AbsolutePath SourceDirectory => RootDirectory / "src";
 
     /// <summary>
     /// Token used to interact with GitHub API
@@ -112,7 +106,7 @@ public class Pipeline : EnhancedNukeBuild,
     public static int Main() => Execute<Pipeline>(x => ((ICompile)x).Compile);
 
     ///<inheritdoc/>
-    IEnumerable<AbsolutePath> IPack.PackableProjects => SourceDirectory.GlobFiles("**/*.csproj");
+    IEnumerable<AbsolutePath> IPack.PackableProjects => this.Get<IHaveSourceDirectory>().SourceDirectory.GlobFiles("**/*.csproj");
 
     ///<inheritdoc/>
     IEnumerable<AbsolutePath> ICreateGithubRelease.Assets => this.Get<IPack>().OutputDirectory.GlobFiles("**/*.nupkg;**/*.snupkg");

--- a/build/Pipeline.cs
+++ b/build/Pipeline.cs
@@ -59,7 +59,7 @@ using static Nuke.Common.Tools.Git.GitTasks;
             "LICENSE"
         ])]
 [DotNetVerbosityMapping]
-public class Pipeline : NukeBuild,
+public class Pipeline : EnhancedNukeBuild,
     IHaveSourceDirectory,
     IHaveSolution,
     IHaveChangeLog,
@@ -90,7 +90,7 @@ public class Pipeline : NukeBuild,
     [Required]
     [Solution]
     public Solution Solution;
-
+    
     ///<inheritdoc/>
     Solution IHaveSolution.Solution => Solution;
 

--- a/build/Pipeline.cs
+++ b/build/Pipeline.cs
@@ -1,10 +1,7 @@
-namespace Candoumbe.Pipelines.Build;
-
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Candoumbe.Pipelines.Components;
-using Candoumbe.Pipelines.Components.Formatting;
 using Candoumbe.Pipelines.Components.GitHub;
 using Candoumbe.Pipelines.Components.NuGet;
 using Candoumbe.Pipelines.Components.Workflows;
@@ -13,10 +10,13 @@ using Nuke.Common.CI;
 using Nuke.Common.CI.GitHubActions;
 using Nuke.Common.IO;
 using Nuke.Common.ProjectModel;
-using Nuke.Common.Tooling;
 using Nuke.Common.Tools.DotNet;
+using Nuke.Common.Tools.Git;
 using Nuke.Common.Tools.GitHub;
-using static Nuke.Common.Tools.Git.GitTasks;
+
+namespace Candoumbe.Pipelines.Build;
+
+using static GitTasks;
 
 [GitHubActions("integration",
     GitHubActionsImage.UbuntuLatest,
@@ -78,7 +78,7 @@ public class Pipeline : EnhancedNukeBuild,
     IEnumerable<AbsolutePath> IClean.DirectoriesToDelete => this.Get<IHaveSourceDirectory>().SourceDirectory.GlobDirectories("**/*/bin", "**/*/obj");
 
     ///<inheritdoc/>
-    IEnumerable<AbsolutePath> IClean.DirectoriesToEnsureExistance => new[]
+    IEnumerable<AbsolutePath> IClean.DirectoriesToEnsureExistence => new[]
     {
         this.Get<IHaveArtifacts>().OutputDirectory,
         this.Get<IHaveArtifacts>().ArtifactsDirectory,

--- a/src/Candoumbe.Pipelines/Components/Configuration.cs
+++ b/src/Candoumbe.Pipelines/Components/Configuration.cs
@@ -19,7 +19,12 @@ namespace Candoumbe.Pipelines.Components
         /// </summary>
         public static readonly Configuration Release = new() { Value = nameof(Release) };
 
-        ///<inheritdoc/>
+        
+        /// <summary>
+        /// Implicit operator to convert a <see cref="Configuration"/> to <see langword="string"/>.
+        /// </summary>
+        /// <param name="configuration"></param>
+        /// <returns>The value of the configuration</returns>
         public static implicit operator string(Configuration configuration) => configuration.Value;
     }
 }

--- a/src/Candoumbe.Pipelines/Components/EnhancedNukeBuild.cs
+++ b/src/Candoumbe.Pipelines/Components/EnhancedNukeBuild.cs
@@ -1,3 +1,4 @@
+using Candoumbe.Pipelines.Components.Workflows;
 using Nuke.Common;
 
 namespace Candoumbe.Pipelines.Components;
@@ -5,9 +6,13 @@ namespace Candoumbe.Pipelines.Components;
 /// <summary>
 /// Represents an enhanced version of the <see cref="NukeBuild"/> class which adds various options support from components.
 /// </summary>
-public abstract class EnhancedNukeBuild : NukeBuild, ICanSkipConfirmation
+public abstract class EnhancedNukeBuild : NukeBuild, ICanSkipConfirmation, ICanAutoStash
 {
     /// <inheritdoc />
     [Parameter("Set to true to not ask any confirmation to the end user (default: false)")]
     public bool SkipConfirmation { get; set; }
+
+    /// <inheritdoc />
+    [Parameter("Indicates if any changes should be stashed automatically prior to switching branch (Default : true)")]
+    public bool AutoStash { get; set; } = true;
 }

--- a/src/Candoumbe.Pipelines/Components/EnhancedNukeBuild.cs
+++ b/src/Candoumbe.Pipelines/Components/EnhancedNukeBuild.cs
@@ -5,7 +5,7 @@ namespace Candoumbe.Pipelines.Components;
 /// <summary>
 /// Represents an enhanced version of the <see cref="NukeBuild"/> class which adds various options support from components.
 /// </summary>
-public class EnhancedNukeBuild : NukeBuild, ICanSkipConfirmation
+public abstract class EnhancedNukeBuild : NukeBuild, ICanSkipConfirmation
 {
     /// <inheritdoc />
     [Parameter("Set to true to not ask any confirmation to the end user (default: false)")]

--- a/src/Candoumbe.Pipelines/Components/EnhancedNukeBuild.cs
+++ b/src/Candoumbe.Pipelines/Components/EnhancedNukeBuild.cs
@@ -1,0 +1,13 @@
+using Nuke.Common;
+
+namespace Candoumbe.Pipelines.Components;
+
+/// <summary>
+/// Represents an enhanced version of the <see cref="NukeBuild"/> class which adds various options support from components.
+/// </summary>
+public class EnhancedNukeBuild : NukeBuild, ICanSkipConfirmation
+{
+    /// <inheritdoc />
+    [Parameter("Set to true to not ask any confirmation to the end user (default: false)")]
+    public bool SkipConfirmation { get; set; }
+}

--- a/src/Candoumbe.Pipelines/Components/GitHub/IGitFlowWithPullRequest.cs
+++ b/src/Candoumbe.Pipelines/Components/GitHub/IGitFlowWithPullRequest.cs
@@ -47,7 +47,7 @@ public interface IGitFlowWithPullRequest : IGitFlow, IPullRequest
 
             string title = Title;
             string token = GitHubToken;
-            if (!Quiet)
+            if (!SkipConfirmation)
             {
                 title = (Console.ReadLine()) switch
                 {
@@ -77,7 +77,7 @@ public interface IGitFlowWithPullRequest : IGitFlow, IPullRequest
 
                 PullRequest pullRequest = await gitHubClient.PullRequest.Create(owner, repositoryName, newPullRequest);
 
-                if (Quiet)
+                if (SkipConfirmation)
                 {
                     DeleteLocalBranchIf(DeleteLocalOnSuccess 
                                         && PromptForChoice("Delete branch {BranchName} ?  (Y/N)", BuildChoices()) == ConsoleKey.Y, branchName, switchToBranchName: FeatureBranchSourceName);

--- a/src/Candoumbe.Pipelines/Components/GitHub/IGitHubFlowWithPullRequest.cs
+++ b/src/Candoumbe.Pipelines/Components/GitHub/IGitHubFlowWithPullRequest.cs
@@ -80,7 +80,7 @@ namespace Candoumbe.Pipelines.Components.GitHub
 
             string title = Title;
             string token = GitHubToken;
-            if (!Quiet)
+            if (!SkipConfirmation)
             {
                 Information(@"Title of the pull request (or ""{PullRequestName}"" if empty)", Title);
                 title = (Console.ReadLine()) switch
@@ -116,7 +116,7 @@ namespace Candoumbe.Pipelines.Components.GitHub
 
                 PullRequest pullRequest = await gitHubClient.PullRequest.Create(owner, repositoryName, newPullRequest);
 
-                if (Quiet)
+                if (SkipConfirmation)
                 {
                     DeleteLocalBranchIf(DeleteLocalOnSuccess 
                                         && PromptForChoice("Delete branch {BranchName} ?  (Y/N)", BuildChoices()) == ConsoleKey.Y, branchName, switchToBranchName: FeatureBranchSourceName);

--- a/src/Candoumbe.Pipelines/Components/ICanSkipConfirmation.cs
+++ b/src/Candoumbe.Pipelines/Components/ICanSkipConfirmation.cs
@@ -1,5 +1,4 @@
 using Nuke.Common;
-using Nuke.Common.Tools.CorFlags;
 
 namespace Candoumbe.Pipelines.Components;
 /// <summary>
@@ -7,11 +6,10 @@ namespace Candoumbe.Pipelines.Components;
 /// </summary>/// <summary>
 /// Interface for components that allow skipping confirmation to end user
 /// </summary>
-public interface ICanSkipConfirmation
+public interface ICanSkipConfirmation : INukeBuild
 {
     /// <summary>
     /// Allow to skip asking confirmation to end user
     /// </summary>
-    [Parameter("Set to true to not ask any confirmation to the end user (default: false)")]
-    bool Quiet => false;
+    bool SkipConfirmation { get; }
 }

--- a/src/Candoumbe.Pipelines/Components/IClean.cs
+++ b/src/Candoumbe.Pipelines/Components/IClean.cs
@@ -23,7 +23,7 @@ public interface IClean : INukeBuild
     /// <summary>
     /// Collection of directories that <see cref="Clean"/> target will make sure exist.
     /// </summary>
-    IEnumerable<AbsolutePath> DirectoriesToEnsureExistance => Enumerable.Empty<AbsolutePath>();
+    IEnumerable<AbsolutePath> DirectoriesToEnsureExistence => Enumerable.Empty<AbsolutePath>();
 
     /// <summary>
     /// Performs the clean up
@@ -32,11 +32,11 @@ public interface IClean : INukeBuild
        .TryBefore<IRestore>(x => x.Restore)
        .OnlyWhenDynamic(() => DirectoriesToClean.AtLeastOnce()
                               || DirectoriesToDelete.AtLeastOnce()
-                              || DirectoriesToEnsureExistance.AtLeastOnce())
+                              || DirectoriesToEnsureExistence.AtLeastOnce())
        .Executes(() =>
        {
            DirectoriesToDelete.ForEach(directory => directory.DeleteDirectory());
            DirectoriesToClean.ForEach(directory => directory.CreateOrCleanDirectory());
-           DirectoriesToEnsureExistance.ForEach(directory => directory.CreateDirectory());
+           DirectoriesToEnsureExistence.ForEach(directory => directory.CreateDirectory());
        });
 }

--- a/src/Candoumbe.Pipelines/Components/IHaveConfiguration.cs
+++ b/src/Candoumbe.Pipelines/Components/IHaveConfiguration.cs
@@ -13,6 +13,6 @@ public interface IHaveConfiguration : INukeBuild
     /// <summary>
     /// Configuration currently supported by the pipeline
     /// </summary>
-    [Parameter("Defines the configuratoin to use when building the application")]
+    [Parameter("Defines the configuration to use when building the application")]
     Configuration Configuration => TryGetValue(() => Configuration) ?? (IsLocalBuild ? Configuration.Debug : Configuration.Release);
 }

--- a/src/Candoumbe.Pipelines/Components/Workflows/ICanAutoStash.cs
+++ b/src/Candoumbe.Pipelines/Components/Workflows/ICanAutoStash.cs
@@ -1,0 +1,12 @@
+namespace Candoumbe.Pipelines.Components.Workflows;
+
+/// <summary>
+/// Enable/Disable support for stashing ongoing work
+/// </summary>
+public interface ICanAutoStash
+{
+    /// <summary>
+    /// Indicates if any changes should be stashed automatically prior to switching branch (Default : true
+    /// </summary>
+    bool AutoStash { get; }
+}

--- a/src/Candoumbe.Pipelines/Components/Workflows/IWorkflow.cs
+++ b/src/Candoumbe.Pipelines/Components/Workflows/IWorkflow.cs
@@ -12,14 +12,8 @@ namespace Candoumbe.Pipelines.Components.Workflows;
 /// <summary>
 /// Marker interface for git repository that support a specific workflow
 /// </summary>
-public interface IWorkflow : IHaveGitRepository, IHaveGitVersion, IHaveChangeLog, ICanSkipConfirmation
+public interface IWorkflow : IHaveGitRepository, IHaveGitVersion, IHaveChangeLog, ICanSkipConfirmation, ICanAutoStash
 {
-    /// <summary>
-    /// Indicates if any changes should be stashed automatically prior to switching branch (Default : true
-    /// </summary>
-    [Parameter("Indicates if any changes should be stashed automatically prior to switching branch (Default : true)")]
-    bool AutoStash => true;
-
     /// <summary>
     /// Name of the branch to create
     /// </summary>

--- a/src/Candoumbe.Pipelines/Components/Workflows/IWorkflow.cs
+++ b/src/Candoumbe.Pipelines/Components/Workflows/IWorkflow.cs
@@ -36,7 +36,7 @@ public interface IWorkflow : IHaveGitRepository, IHaveGitVersion, IHaveChangeLog
         {
             FinalizeChangelog(ChangeLogFile, GitVersion.MajorMinorPatch, GitRepository);
 
-            if (IsLocalBuild && !Quiet)
+            if (IsLocalBuild && !SkipConfirmation)
             {
                 Information("Please review CHANGELOG.md ({ChangeLogFile}) and press 'Y' to validate (any other key will cancel changes)...", ChangeLogFile);
                 ConsoleKeyInfo keyInfo = Console.ReadKey();
@@ -69,7 +69,7 @@ public interface IWorkflow : IHaveGitRepository, IHaveGitVersion, IHaveChangeLog
     /// <param name="sourceBranch">Branch from which a new branch will be created</param>
     protected void AskBranchNameAndSwitchToIt(string branchNamePrefix, string sourceBranch)
     {
-        if (!Quiet)
+        if (!SkipConfirmation)
         {
             Information("Enter the name of the coldfix. It will be used as the name of the coldfix/branch (leave empty to exit) :");
 


### PR DESCRIPTION
### 🚀 New features
• Enabled TerminalLogger ([#138](https://github.com/candoumbe/Pipelines/issues/138))
• Added a new --skip-confirmation option to skip asking confirmations ([#145](https://github.com/candoumbe/Pipelines/issues/145)).

Full changelog at https://github.com/candoumbe/Pipelines/blob/coldfix/rename-option-to-skip-confirmation/CHANGELOG.md