### PR TITLE
🧹 Create Major Release Hint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `Filter` option to specifiy which benchmarks to perform
 - Added `NuGetApiKey` parameter to `IPushNugetPackages` component
 
+### 🛠️ Fixes
+- Fixed `--major` parameter not read from command line when creating a release branch.
+
 
 ## [0.13.4] / 2025-08-18
 ### 🛠️ Fixes

--- a/src/Candoumbe.Pipelines/Components/IHaveGitVersion.cs
+++ b/src/Candoumbe.Pipelines/Components/IHaveGitVersion.cs
@@ -25,7 +25,7 @@ public interface IHaveGitVersion : INukeBuild, IRequireNuGetPackage
     /// The value of this property is only taken into account when running <see cref="Release"/> target.
     /// </remarks>
     [Parameter("Hint to create a major release.")]
-    bool Major => false;
+    bool Major => TryGetValue<bool?>(() => Major) ?? false;
 
     /// <summary>
     /// Major.Minor.Patch Version number


### PR DESCRIPTION
### 🚀 New features
• Added Filter option to specifiy which benchmarks to perform
• Added NuGetApiKey parameter to IPushNugetPackages component
### 🛠️ Fixes
• Fixed --major parameter not read from command line when creating a release branch.

Full changelog at https://github.com/candoumbe/Pipelines/blob/coldfix/create-major-release-hint/CHANGELOG.md