### PR TITLE
🧹 Duplicate prompts when creating coldfix or feature branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### 🛠️ Fixes
+- Removed repetitive confirmation prompts when creating new branches ([#161](https://github.com/candoumbe/pipelines/issues/161)).
+
 ### 🚀 New features
 - Added `IRegenerateWorkflows` component that can be used to regenerate workflow files ([#203](https://github.com/candoumbe/pipelines/issues/203)).
 - Added `ICanRegenerateGitHubWorkflow` component that can be used to regenerate GitHub workflow files.

--- a/src/Candoumbe.Pipelines/Components/Workflows/IDoChoreWorkflow.cs
+++ b/src/Candoumbe.Pipelines/Components/Workflows/IDoChoreWorkflow.cs
@@ -50,9 +50,7 @@ public interface IDoChoreWorkflow : IWorkflow
        {
            if (!GitRepository.Branch.Like($"{ChoreBranchPrefix}/*", true) || !GitHasCleanWorkingCopy())
            {
-               Information("Enter the name of the chore. It will be used as the name of the chore/branch (leave empty to exit) :");
                AskBranchNameAndSwitchToIt(ChoreBranchPrefix, sourceBranch: ChoreBranchSourceName);
-               Information("Good bye !");
            }
            else
            {

--- a/src/Candoumbe.Pipelines/Components/Workflows/IDoColdfixWorkflow.cs
+++ b/src/Candoumbe.Pipelines/Components/Workflows/IDoColdfixWorkflow.cs
@@ -45,7 +45,6 @@ public interface IDoColdfixWorkflow : IDoFeatureWorkflow
             if (!GitRepository.Branch.Like($"{ColdfixBranchPrefix}/*"))
             {
                 AskBranchNameAndSwitchToIt(ColdfixBranchPrefix, ColdfixBranchSourceName);
-                Information($"{EnvironmentInfo.NewLine}Good bye !");
             }
             else
             {

--- a/src/Candoumbe.Pipelines/Components/Workflows/IDoFeatureWorkflow.cs
+++ b/src/Candoumbe.Pipelines/Components/Workflows/IDoFeatureWorkflow.cs
@@ -48,9 +48,7 @@ public interface IDoFeatureWorkflow : IWorkflow
        {
            if (!GitRepository.IsOnFeatureBranch())
            {
-               Information("Enter the name of the feature. It will be used as the name of the feature/branch (leave empty to exit) :");
                AskBranchNameAndSwitchToIt(FeatureBranchPrefix, sourceBranch: FeatureBranchSourceName);
-               Information("Good bye !");
            }
            else
            {

--- a/src/Candoumbe.Pipelines/Components/Workflows/IWorkflow.cs
+++ b/src/Candoumbe.Pipelines/Components/Workflows/IWorkflow.cs
@@ -65,7 +65,8 @@ public interface IWorkflow : IHaveGitRepository, IHaveGitVersion, IHaveChangeLog
     {
         if (!SkipConfirmation)
         {
-            Information("Enter the name of the coldfix. It will be used as the name of the coldfix/branch (leave empty to exit) :");
+            Information("Enter the name of the new branch. It will be used as the name of the {BranchPrefix}/{{your-branch-name}} (leave empty to exit) :",
+                branchNamePrefix);
 
             string featureName;
             bool exitCreatingFeature;
@@ -82,7 +83,10 @@ public interface IWorkflow : IHaveGitRepository, IHaveGitVersion, IHaveChangeLog
                     {
                         string branchName = ComputeSanitizedFeatureBranchName(branchNamePrefix, featureName);
                         Information(
-                            $"The branch '{{BranchName}}' will be created.{Environment.NewLine}Confirm ? (Y/N) ",
+                            """
+                            The branch '{BranchName}' will be created.
+                            Confirm ? (Y/N)
+                            """,
                             branchName);
 
                         switch (Console.ReadKey().Key)


### PR DESCRIPTION
### 🛠️ Fixes
• Removed repetitive confirmation prompts when creating new branches ([#161](https://github.com/candoumbe/pipelines/issues/161)).
### 🚀 New features
• Added IRegenerateWorkflows component that can be used to regenerate workflow files ([#203](https://github.com/candoumbe/pipelines/issues/203)).
• Added ICanRegenerateGitHubWorkflow component that can be used to regenerate GitHub workflow files.

Full changelog at https://github.com/candoumbe/Pipelines/blob/coldfix/duplicate-message-when-creating-coldfix-or-feature-branch/CHANGELOG.md

Resolves #161