### PR TITLE
💪🏾 Chore/Add Unit Tests

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,8 @@
   "name": "Candoumbe.Pipelines",
   "image": "mcr.microsoft.com/devcontainers/dotnet:10.0",
   "features": {
-    "ghcr.io/devcontainers/features/git:1": {}
+    "ghcr.io/devcontainers/features/git:1": {},
+    "ghcr.io/devcontainers/features/copilot-cli": {} 
   },
   "runArgs": [
     "--userns=keep-id"

--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -42,6 +42,10 @@ jobs:
             .nuke/temp
             ~/.nuget/packages
           key: ${{ runner.os }}-${{ hashFiles('global.json', 'src/**/*.csproj') }}
+      - name: setup-dotnet
+        uses: actions/setup-dotnet@v3
+        with:
+          global-json-file: global.json
       - name: 'Run: Compile, Pack, Publish'
         run: ./build.cmd Compile Pack Publish
         env:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -42,6 +42,10 @@ jobs:
             .nuke/temp
             ~/.nuget/packages
           key: ${{ runner.os }}-${{ hashFiles('global.json', 'src/**/*.csproj') }}
+      - name: setup-dotnet
+        uses: actions/setup-dotnet@v3
+        with:
+          global-json-file: global.json
       - name: 'Run: Compile, Pack, Publish'
         run: ./build.cmd Compile Pack Publish
         env:

--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -37,7 +37,8 @@
         "Publish",
         "RegenerateWorkflow",
         "Release",
-        "Restore"
+        "Restore",
+        "UnitTests"
       ]
     },
     "Verbosity": {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,7 @@ build/
 - Private fields use `_camelCase` prefix.
 - Interfaces are named `IPascalCase`.
 - Namespace must match folder structure.
+- 1 file per class, 1 class per file
 
 ## Build and Test
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,75 @@
+# Project Guidelines
+
+## Architecture
+
+This project is a **component-based CI/CD framework** built on top of [NUKE](https://nuke.build/). It provides reusable, composable pipeline components as C# interfaces with default implementations.
+
+### Core Design Principles
+
+- **Interface-based composition**: Each pipeline capability (clean, restore, compile, test, pack, publish…) is a separate interface (e.g., `IClean`, `ICompile`, `IPack`). Pipelines compose behavior by implementing multiple interfaces.
+- **Convention over configuration**: Components provide opinionated defaults. Override only when necessary.
+- **Infrastructure interfaces prefix with `IHave`** (e.g., `IHaveSourceDirectory`, `IHaveArtifacts`): these expose paths, settings, or external resources.
+- **Action interfaces prefix with `I` + verb** (e.g., `ICompile`, `IRestore`, `IPack`): these define executable build targets.
+- **Workflow interfaces prefix with `IDo`** (e.g., `IDoFeatureWorkflow`, `IDoChoreWorkflow`): these define branching strategies.
+
+### Project Structure
+
+```
+src/
+  Candoumbe.Pipelines/                          # Core library — NuGet package
+    Components/                                  # All component interfaces
+      IClean.cs, ICompile.cs, IRestore.cs, …    # Build target components
+      IHaveSolution.cs, IHaveArtifacts.cs, …    # Infrastructure components
+      Docker/                                    # Docker-related components
+      Formatting/                                # Code formatting (IDotnetFormat)
+      GitHub/                                    # GitHub integration (releases, PRs)
+      NuGet/                                     # NuGet publishing
+      Workflows/                                 # Git branching strategies (GitFlow, GitHubFlow)
+    tools/Stryker/                               # Stryker.NET config for mutation testing
+  Candoumbe.Pipelines.Components.AzureDevOps/    # Standalone Azure DevOps extension package
+build/
+  Pipeline.cs                                    # Self-hosting build — consumes the library
+```
+
+**Do not break this structure.** New components go in the appropriate subdirectory under `Components/`. New provider-specific integrations go in a separate project (like `Candoumbe.Pipelines.Components.AzureDevOps`).
+
+### Adding a New Component
+
+1. Create an interface in the appropriate `Components/` subdirectory.
+2. Follow the naming conventions: `IHave*` for infrastructure, `I{Verb}` for build targets, `IDo*Workflow` for branching strategies.
+3. The interface should inherit from the relevant base interfaces (e.g., `INukeBuild`, `IHaveSolution`).
+4. Provide a default implementation via interface default methods.
+5. Ensure the component is composable — avoid tight coupling with other components.
+
+## Code Style
+
+- **C# latest** language version with **.NET 10** (also targets .NET 8).
+- Follow the [.editorconfig](.editorconfig): 4-space indentation, `var` only for inferred types (enforced as error), switch expressions preferred.
+- Private fields use `_camelCase` prefix.
+- Interfaces are named `IPascalCase`.
+- Namespace must match folder structure.
+
+## Build and Test
+
+```bash
+# Build the solution
+./build.sh compile
+
+# Create NuGet packages
+./build.sh pack
+
+# Run all default targets
+./build.sh
+```
+
+The build uses NUKE via [build/Pipeline.cs](build/Pipeline.cs). The `Pipeline` class itself composes components from this library.
+
+Package versions are managed centrally in [Directory.Packages.props](Directory.Packages.props).
+
+## Conventions
+
+- **Semantic versioning** via [GitVersion](https://gitversion.net/) — never set versions manually.
+- **Changelog** follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format in [CHANGELOG.md](CHANGELOG.md).
+- **Branching model**: GitFlow — `feature/*`, `hotfix/*`, `release/*`, `chore/*`, `coldfix/*` branches from `develop`.
+- **GitHub workflows** are auto-generated from `Pipeline.cs` via `ICanRegenerateGitHubWorkflows` — do not edit `.github/workflows/*.yml` manually.
+- **Central package management** is enabled — add package versions in `Directory.Packages.props`, not in individual `.csproj` files.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,545 @@
+# Contributing to Candoumbe.Pipelines
+
+Thank you for your interest in contributing! This document outlines the coding conventions, style rules, and best practices you should follow when working on this project.
+
+## Table of Contents
+
+- [Prerequisites](#prerequisites)
+- [Project Structure](#project-structure)
+- [Branching Model](#branching-model)
+- [Naming Conventions](#naming-conventions)
+- [Code Style](#code-style)
+- [Component Design](#component-design)
+- [Testing](#testing)
+- [Package Management](#package-management)
+- [Versioning & Changelog](#versioning--changelog)
+- [CI/CD Workflows](#cicd-workflows)
+- [Build Commands](#build-commands)
+
+---
+
+## Prerequisites
+
+- **.NET SDK 10.0** (also targets .NET 8.0)
+- **C# latest** language version
+- An editor that respects [`.editorconfig`](.editorconfig) (VS Code, Visual Studio, Rider…)
+
+---
+
+## Project Structure
+
+```
+src/
+  Candoumbe.Pipelines/                          # Core library (NuGet package)
+    Components/                                  # All component interfaces
+      Docker/                                    # Docker-related components
+      Formatting/                                # Code formatting components
+      GitHub/                                    # GitHub integration
+      NuGet/                                     # NuGet publishing
+      Workflows/                                 # Git branching strategies
+  Candoumbe.Pipelines.Components.AzureDevOps/    # Azure DevOps extension (separate package)
+build/
+  Pipeline.cs                                    # Self-hosting build pipeline
+test/
+  Candoumbe.Pipelines.Tests/                     # Unit tests
+```
+
+**Rules:**
+
+- New components go in the appropriate subdirectory under `Components/`.
+- New provider-specific integrations go in a **separate project** (like `Candoumbe.Pipelines.Components.AzureDevOps`).
+- **1 file per type, 1 type per file.**
+- **Namespace must match folder structure.**
+
+---
+
+## Branching Model
+
+This project uses **GitFlow**. Branch prefixes:
+
+| Branch type   | Prefix        | Source branch |
+|---------------|---------------|---------------|
+| Feature       | `feature/`    | `develop`     |
+| Hotfix        | `hotfix/`     | `main`        |
+| Coldfix       | `coldfix/`    | `develop`     |
+| Release       | `release/`    | `develop`     |
+| Chore         | `chore/`      | `develop`     |
+
+> **Never commit directly to `main` or `develop`.**
+
+---
+
+## Naming Conventions
+
+### Interfaces
+
+| Category       | Prefix     | Purpose                         | Examples                                      |
+|----------------|------------|----------------------------------|-----------------------------------------------|
+| Infrastructure | `IHave`    | Expose paths, settings, resources | `IHaveArtifacts`, `IHaveSolution`             |
+| Action         | `I` + Verb | Define executable build targets   | `IClean`, `ICompile`, `IPack`, `IRestore`     |
+| Workflow       | `IDo`      | Define branching strategies       | `IDoFeatureWorkflow`, `IDoChoreWorkflow`      |
+
+### Fields
+
+| Visibility              | Style            | Example                    |
+|--------------------------|------------------|----------------------------|
+| Private / Protected      | `_camelCase`     | `_outputDirectory`         |
+| Private static readonly  | `s_camelCase`    | `s_defaultConfig`          |
+| Public / Internal        | `PascalCase`     | `OutputDirectory`          |
+| Constants                | `PascalCase`     | `DevelopBranchName`        |
+
+### General
+
+- Classes, structs, enums, delegates: `PascalCase`
+- Interfaces: `IPascalCase` (prefix with `I`)
+- Parameters: `camelCase`
+- Methods, properties, events: `PascalCase`
+
+---
+
+## Code Style
+
+### Use explicit types — `var` is **not** allowed
+
+This is **enforced as an error** in the `.editorconfig`.
+
+```csharp
+// ✅ DO — use explicit types
+AbsolutePath directory = RootDirectory / "src";
+string name = "example";
+int count = 42;
+IEnumerable<AbsolutePath> paths = Enumerable.Empty<AbsolutePath>();
+
+// ❌ DON'T — never use var
+var directory = RootDirectory / "src";
+var name = "example";
+var count = 42;
+var paths = Enumerable.Empty<AbsolutePath>();
+```
+
+### Indentation and spacing
+
+- **4 spaces** for indentation (no tabs).
+- **2 spaces** for `.csproj`, `.json`, `.props`, `.xml`, `.yaml`, `.yml` files.
+
+### Braces
+
+Always use braces, even for single-line blocks (enforced as warning).
+
+```csharp
+// ✅ DO
+if (condition)
+{
+    DoSomething();
+}
+
+// ❌ DON'T
+if (condition)
+    DoSomething();
+```
+
+### Brace placement
+
+Allman style — opening braces on a new line.
+
+```csharp
+// ✅ DO
+public class MyClass
+{
+    public void MyMethod()
+    {
+        // ...
+    }
+}
+
+// ❌ DON'T
+public class MyClass {
+    public void MyMethod() {
+        // ...
+    }
+}
+```
+
+### Switch expressions preferred
+
+Use switch expressions over switch statements (enforced as error).
+
+```csharp
+// ✅ DO
+string result = status switch
+{
+    Status.Active => "active",
+    Status.Inactive => "inactive",
+    _ => "unknown"
+};
+
+// ❌ DON'T
+string result;
+switch (status)
+{
+    case Status.Active:
+        result = "active";
+        break;
+    case Status.Inactive:
+        result = "inactive";
+        break;
+    default:
+        result = "unknown";
+        break;
+}
+```
+
+### Using directives
+
+- Place `using` directives **outside** the namespace (enforced as error).
+- Sort `System` directives first.
+
+```csharp
+// ✅ DO
+using System;
+using System.Collections.Generic;
+using Nuke.Common;
+
+namespace Candoumbe.Pipelines.Components;
+
+// ❌ DON'T
+namespace Candoumbe.Pipelines.Components
+{
+    using System;
+    using Nuke.Common;
+}
+```
+
+### File-scoped namespaces
+
+Prefer file-scoped namespace declarations.
+
+```csharp
+// ✅ DO
+namespace Candoumbe.Pipelines.Components;
+
+public interface IHaveArtifacts : IHaveOutputDirectory
+{
+    // ...
+}
+
+// ❌ DON'T (unless existing code uses block-scoped)
+namespace Candoumbe.Pipelines.Components
+{
+    public interface IHaveArtifacts : IHaveOutputDirectory
+    {
+        // ...
+    }
+}
+```
+
+### Null handling
+
+- Use null propagation (`?.`) — enforced as warning.
+- Use null coalescing (`??`) — enforced as warning.
+- Prefer `is null` / `is not null` over `== null` / `!= null`.
+
+```csharp
+// ✅ DO
+string value = input ?? "default";
+int? length = text?.Length;
+if (obj is not null) { ... }
+
+// ❌ DON'T
+string value = input != null ? input : "default";
+int? length = text != null ? text.Length : null;
+if (obj != null) { ... }
+```
+
+### Object initializers and collection expressions
+
+Prefer object initializers and collection expressions (enforced as warning).
+
+```csharp
+// ✅ DO
+Person person = new() { Name = "Alice", Age = 30 };
+IEnumerable<Project> projects = [];
+
+// ❌ DON'T
+Person person = new Person();
+person.Name = "Alice";
+person.Age = 30;
+List<Project> projects = new List<Project>();
+```
+
+### Predefined types
+
+Use predefined types (`string`, `int`, `bool`) instead of framework names (enforced as error for locals/parameters).
+
+```csharp
+// ✅ DO
+string name = "example";
+int count = 0;
+
+// ❌ DON'T
+String name = "example";
+Int32 count = 0;
+```
+
+---
+
+## Component Design
+
+### Infrastructure interface (`IHave*`)
+
+Infrastructure interfaces expose paths, settings, or external resources. They inherit from `INukeBuild` and provide default implementations.
+
+```csharp
+// ✅ DO — simple, composable infrastructure interface
+using Nuke.Common;
+using Nuke.Common.IO;
+
+namespace Candoumbe.Pipelines.Components;
+
+/// <summary>
+/// Marks a pipeline that can specify a folder for source files
+/// </summary>
+public interface IHaveSourceDirectory : INukeBuild
+{
+    /// <summary>
+    /// Directory of source code projects
+    /// </summary>
+    AbsolutePath SourceDirectory => RootDirectory / "src";
+}
+```
+
+### Action interface (`I` + Verb)
+
+Action interfaces define executable build targets. They inherit from the infrastructure interfaces they need.
+
+```csharp
+// ✅ DO — action interface with default target implementation
+using System.Collections.Generic;
+using System.Linq;
+using Nuke.Common;
+using Nuke.Common.IO;
+
+namespace Candoumbe.Pipelines.Components;
+
+/// <summary>
+/// Marks a pipeline that supports cleaning workflow.
+/// </summary>
+public interface IClean : INukeBuild
+{
+    IEnumerable<AbsolutePath> DirectoriesToDelete => Enumerable.Empty<AbsolutePath>();
+
+    IEnumerable<AbsolutePath> DirectoriesToClean => Enumerable.Empty<AbsolutePath>();
+
+    IEnumerable<AbsolutePath> DirectoriesToEnsureExistence => Enumerable.Empty<AbsolutePath>();
+
+    public Target Clean => _ => _
+       .TryBefore<IRestore>(x => x.Restore)
+       .OnlyWhenDynamic(() => DirectoriesToClean.AtLeastOnce()
+                              || DirectoriesToDelete.AtLeastOnce()
+                              || DirectoriesToEnsureExistence.AtLeastOnce())
+       .Executes(() =>
+       {
+           DirectoriesToDelete.ForEach(directory => directory.DeleteDirectory());
+           DirectoriesToClean.ForEach(directory => directory.CreateOrCleanDirectory());
+           DirectoriesToEnsureExistence.ForEach(directory => directory.CreateDirectory());
+       });
+}
+```
+
+### Key design rules
+
+```csharp
+// ✅ DO — compose interfaces to build capabilities
+public interface ICompile : IHaveSolution, IHaveConfiguration { ... }
+
+// ✅ DO — provide sealed base settings and overridable settings
+public sealed Configure<DotNetBuildSettings> CompileSettingsBase => _ => _
+    .SetProjectFile(Solution)
+    .SetConfiguration(Configuration);
+
+public Configure<DotNetBuildSettings> CompileSettings => _ => _;
+
+// ✅ DO — use TryDependsOn / TryBefore for optional dependencies
+public Target Compile => _ => _
+    .TryDependsOn<IRestore>()
+    .TryDependsOn<IFormat>()
+    .Executes(() => { ... });
+
+// ❌ DON'T — tightly couple components
+public interface ICompile : IRestore, IFormat, IClean { ... }  // Too many hard dependencies
+```
+
+---
+
+## Testing
+
+### Framework
+
+- **xUnit** for test framework
+- **FluentAssertions** for assertions
+- **NSubstitute** for mocking
+
+### Test naming convention
+
+Use descriptive method names following the pattern:
+`Given_<precondition>_When_<action>_Then_<expected result>`
+
+```csharp
+// ✅ DO
+[Fact]
+public void Given_DefaultImplementation_When_AccessingDirectoriesToDelete_Then_ReturnsEmptyCollection()
+{
+    // Arrange
+    IClean sut = new CleanBuild();
+
+    // Act
+    IEnumerable<AbsolutePath> actual = sut.DirectoriesToDelete;
+
+    // Assert
+    actual.Should().BeEmpty();
+}
+
+// ❌ DON'T — vague or non-descriptive names
+[Fact]
+public void Test1() { ... }
+
+[Fact]
+public void CleanWorks() { ... }
+```
+
+### Test structure
+
+Use the **Arrange / Act / Assert** pattern with comments.
+
+```csharp
+// ✅ DO
+[Fact]
+public void Given_DefaultImplementation_When_AccessingSourceDirectory_Then_ReturnsExpectedPath()
+{
+    // Arrange
+    IHaveSourceDirectory sut = new SourceDirectoryBuild();
+
+    // Act
+    AbsolutePath actual = sut.SourceDirectory;
+
+    // Assert
+    actual.Should().NotBeNull();
+    actual.ToString().Should().EndWith("src");
+}
+```
+
+### Test build stubs
+
+Create minimal stubs in `TestBuild.cs` for testing interface default implementations.
+
+```csharp
+// ✅ DO — minimal test stubs
+internal class SourceDirectoryBuild : NukeBuild, IHaveSourceDirectory;
+
+internal class CleanBuild : NukeBuild, IClean;
+
+// Stubs that require non-default members implement only what's needed
+internal class PackBuild : NukeBuild, IPack
+{
+    public IEnumerable<AbsolutePath> PackableProjects => [];
+}
+```
+
+### Test file naming
+
+Test files are named after the component they test: `I{Component}Tests.cs`
+
+| Component file                | Test file                   |
+|-------------------------------|-----------------------------|
+| `IClean.cs`                   | `ICleanTests.cs`            |
+| `IHaveArtifacts.cs`           | `IHaveArtifactsTests.cs`    |
+| `Configuration.cs`            | `ConfigurationTests.cs`     |
+
+---
+
+## Package Management
+
+This project uses **Central Package Management**. All package versions are defined in [`Directory.Packages.props`](Directory.Packages.props).
+
+```xml
+<!-- ✅ DO — add version in Directory.Packages.props -->
+<PackageVersion Include="FluentAssertions" Version="8.3.0"/>
+
+<!-- ✅ DO — reference without version in .csproj -->
+<PackageReference Include="FluentAssertions"/>
+
+<!-- ❌ DON'T — specify version in .csproj files -->
+<PackageReference Include="FluentAssertions" Version="8.3.0"/>
+```
+
+---
+
+## Versioning & Changelog
+
+### Versioning
+
+- Uses **[GitVersion](https://gitversion.net/)** for automatic semantic versioning.
+- **Never set versions manually** in `.csproj` files or elsewhere.
+
+### Changelog
+
+- Follows the **[Keep a Changelog](https://keepachangelog.com/en/1.0.0/)** format.
+- Update [`CHANGELOG.md`](CHANGELOG.md) with every user-facing change under the `[Unreleased]` section.
+- Use the standard section headers:
+
+| Section                  | When to use                                    |
+|--------------------------|------------------------------------------------|
+| `### 💥 Breaking changes`| Backward-incompatible API changes              |
+| `### 🚀 New features`    | New functionality                              |
+| `### 🚨 Fixes`           | Bug fixes                                      |
+| `### 🧹 Housekeeping`    | Internal changes, dependency updates, tooling  |
+
+---
+
+## CI/CD Workflows
+
+- GitHub workflow files (`.github/workflows/*.yml`) are **auto-generated** from `build/Pipeline.cs` via `ICanRegenerateGitHubWorkflows`.
+- **Do NOT edit workflow YAML files manually.** They will be overwritten.
+- To change CI behavior, modify `Pipeline.cs` and regenerate.
+
+---
+
+## Build Commands
+
+```bash
+# Build the solution
+./build.sh compile
+
+# Create NuGet packages
+./build.sh pack
+
+# Run all default targets
+./build.sh
+```
+
+---
+
+## Summary of Do's and Don'ts
+
+| ✅ Do | ❌ Don't |
+|-------|---------|
+| Use explicit types everywhere | Use `var` |
+| Use 4-space indentation | Use tabs |
+| Place braces on their own line (Allman style) | Use K&R brace style |
+| Always use braces for control flow | Omit braces for single-line blocks |
+| Use `is null` / `is not null` | Use `== null` / `!= null` |
+| Use switch expressions | Use switch statements |
+| Use file-scoped namespaces | Use block-scoped namespaces (unless existing) |
+| Use predefined types (`string`, `int`) | Use framework types (`String`, `Int32`) |
+| Follow `IHave*` / `I{Verb}` / `IDo*` naming | Invent new interface prefix patterns |
+| Put `using` directives outside namespace | Put `using` inside namespace |
+| Sort `System` usings first | Use unsorted usings |
+| Add package versions in `Directory.Packages.props` | Add versions in `.csproj` files |
+| Update `CHANGELOG.md` for every change | Skip changelog updates |
+| Name tests `Given_When_Then` | Use vague test names |
+| Use Arrange/Act/Assert pattern | Mix test phases |
+| Create branches from `develop` | Commit directly to `main` or `develop` |
+| Let GitVersion manage versions | Set versions manually |
+| Modify `Pipeline.cs` for CI changes | Edit `.github/workflows/*.yml` manually |
+| 1 file per type | Multiple types in one file |
+| Match namespace to folder structure | Use arbitrary namespace names |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -515,8 +515,10 @@ This project uses **Central Package Management**. All package versions are defin
 
 # Run all default targets
 ./build.sh
-```
 
+# Run all unit tests
+./build.sh unit-tests
+```
 ---
 
 ## Summary of Do's and Don'ts

--- a/Candoumbe.Pipelines.sln
+++ b/Candoumbe.Pipelines.sln
@@ -40,22 +40,66 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{2F9EC63F
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Candoumbe.Pipelines.Components.AzureDevOps", "src\Candoumbe.Pipelines.Components.AzureDevOps\Candoumbe.Pipelines.Components.AzureDevOps.csproj", "{F30EE22B-E679-4507-AF59-37DD55589677}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{0C88DD14-F956-CE84-757C-A364CCF449FC}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Candoumbe.Pipelines.Tests", "test\Candoumbe.Pipelines.Tests\Candoumbe.Pipelines.Tests.csproj", "{41259958-9180-45AC-BD76-9BC2B0EE2FA7}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{C5E88444-476F-48DE-9D7D-957027AF8050}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{C5E88444-476F-48DE-9D7D-957027AF8050}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C5E88444-476F-48DE-9D7D-957027AF8050}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{C5E88444-476F-48DE-9D7D-957027AF8050}.Debug|x64.Build.0 = Debug|Any CPU
+		{C5E88444-476F-48DE-9D7D-957027AF8050}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C5E88444-476F-48DE-9D7D-957027AF8050}.Debug|x86.Build.0 = Debug|Any CPU
 		{C5E88444-476F-48DE-9D7D-957027AF8050}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C5E88444-476F-48DE-9D7D-957027AF8050}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C5E88444-476F-48DE-9D7D-957027AF8050}.Release|x64.ActiveCfg = Release|Any CPU
+		{C5E88444-476F-48DE-9D7D-957027AF8050}.Release|x64.Build.0 = Release|Any CPU
+		{C5E88444-476F-48DE-9D7D-957027AF8050}.Release|x86.ActiveCfg = Release|Any CPU
+		{C5E88444-476F-48DE-9D7D-957027AF8050}.Release|x86.Build.0 = Release|Any CPU
 		{0E338605-C882-4485-A018-7FF55EBDDC81}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0E338605-C882-4485-A018-7FF55EBDDC81}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{0E338605-C882-4485-A018-7FF55EBDDC81}.Debug|x64.Build.0 = Debug|Any CPU
+		{0E338605-C882-4485-A018-7FF55EBDDC81}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{0E338605-C882-4485-A018-7FF55EBDDC81}.Debug|x86.Build.0 = Debug|Any CPU
 		{0E338605-C882-4485-A018-7FF55EBDDC81}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0E338605-C882-4485-A018-7FF55EBDDC81}.Release|x64.ActiveCfg = Release|Any CPU
+		{0E338605-C882-4485-A018-7FF55EBDDC81}.Release|x64.Build.0 = Release|Any CPU
+		{0E338605-C882-4485-A018-7FF55EBDDC81}.Release|x86.ActiveCfg = Release|Any CPU
+		{0E338605-C882-4485-A018-7FF55EBDDC81}.Release|x86.Build.0 = Release|Any CPU
 		{F30EE22B-E679-4507-AF59-37DD55589677}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{F30EE22B-E679-4507-AF59-37DD55589677}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F30EE22B-E679-4507-AF59-37DD55589677}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F30EE22B-E679-4507-AF59-37DD55589677}.Debug|x64.Build.0 = Debug|Any CPU
+		{F30EE22B-E679-4507-AF59-37DD55589677}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F30EE22B-E679-4507-AF59-37DD55589677}.Debug|x86.Build.0 = Debug|Any CPU
 		{F30EE22B-E679-4507-AF59-37DD55589677}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F30EE22B-E679-4507-AF59-37DD55589677}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F30EE22B-E679-4507-AF59-37DD55589677}.Release|x64.ActiveCfg = Release|Any CPU
+		{F30EE22B-E679-4507-AF59-37DD55589677}.Release|x64.Build.0 = Release|Any CPU
+		{F30EE22B-E679-4507-AF59-37DD55589677}.Release|x86.ActiveCfg = Release|Any CPU
+		{F30EE22B-E679-4507-AF59-37DD55589677}.Release|x86.Build.0 = Release|Any CPU
+		{41259958-9180-45AC-BD76-9BC2B0EE2FA7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{41259958-9180-45AC-BD76-9BC2B0EE2FA7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{41259958-9180-45AC-BD76-9BC2B0EE2FA7}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{41259958-9180-45AC-BD76-9BC2B0EE2FA7}.Debug|x64.Build.0 = Debug|Any CPU
+		{41259958-9180-45AC-BD76-9BC2B0EE2FA7}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{41259958-9180-45AC-BD76-9BC2B0EE2FA7}.Debug|x86.Build.0 = Debug|Any CPU
+		{41259958-9180-45AC-BD76-9BC2B0EE2FA7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{41259958-9180-45AC-BD76-9BC2B0EE2FA7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{41259958-9180-45AC-BD76-9BC2B0EE2FA7}.Release|x64.ActiveCfg = Release|Any CPU
+		{41259958-9180-45AC-BD76-9BC2B0EE2FA7}.Release|x64.Build.0 = Release|Any CPU
+		{41259958-9180-45AC-BD76-9BC2B0EE2FA7}.Release|x86.ActiveCfg = Release|Any CPU
+		{41259958-9180-45AC-BD76-9BC2B0EE2FA7}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -65,6 +109,7 @@ Global
 		{2840620C-D0A6-4E33-9478-84B34A24D740} = {4E8513FE-04F0-4227-A5B7-7C46E8F3FA90}
 		{0E338605-C882-4485-A018-7FF55EBDDC81} = {2F9EC63F-79BF-4F39-A16C-8AC7C8CA40C6}
 		{F30EE22B-E679-4507-AF59-37DD55589677} = {80DFDD00-A0E2-48D4-A010-DC0378F0758F}
+		{41259958-9180-45AC-BD76-9BC2B0EE2FA7} = {0C88DD14-F956-CE84-757C-A364CCF449FC}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {DC79494F-6B14-48E4-BF37-EEEF6D188157}

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,6 +12,13 @@
   <ItemGroup Condition="'$(IsTestProject)' == 'false'">
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.201"/>
   </ItemGroup>
+  <ItemGroup Condition="'$(IsTestProject)' == 'true'">
+    <PackageVersion Include="FluentAssertions" Version="8.3.0"/>
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.0"/>
+    <PackageVersion Include="NSubstitute" Version="5.3.0"/>
+    <PackageVersion Include="xunit" Version="2.9.3"/>
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.2"/>
+  </ItemGroup>
 
   <Choose>
     <When Condition="'$(TargetFramework)' == 'net8.0'">

--- a/build/Candoumbe.Pipelines.Build.csproj
+++ b/build/Candoumbe.Pipelines.Build.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Candoumbe.Pipelines"/>
+    <ProjectReference Include="..\src\Candoumbe.Pipelines\Candoumbe.Pipelines.csproj"/>
   </ItemGroup>
   <ItemGroup>
     <PackageDownload Include="CodeCovUploader" Version="[0.8.0]"/>

--- a/build/Pipeline.cs
+++ b/build/Pipeline.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Candoumbe.Pipelines.Components;
 using Candoumbe.Pipelines.Components.Formatting;
@@ -58,6 +59,7 @@ using static Nuke.Common.Tools.Git.GitTasks;
 [DotNetVerbosityMapping]
 public class Pipeline : EnhancedNukeBuild,
     IHaveSourceDirectory,
+    IHaveTestDirectory,
     ICanRegenerateGitHubWorkflows,
     IClean,
     IRestore,
@@ -65,6 +67,7 @@ public class Pipeline : EnhancedNukeBuild,
     ICompile,
     IPushNugetPackages,
     ICreateGithubRelease,
+    IUnitTest,
     IDoChoreWorkflow,
     IGitFlowWithPullRequest
 {
@@ -82,12 +85,11 @@ public class Pipeline : EnhancedNukeBuild,
     [Solution]
     public Solution Solution;
 
-    IEnumerable<Project> _unitTestsProjects;
-    IEnumerable<Project> _integrationTestsProjects;
-    IEnumerable<MutationProjectConfiguration> _mutationTestsProjects;
-
     ///<inheritdoc/>
     Solution IHaveSolution.Solution => Solution;
+
+    ///<inheritdoc/>
+    IEnumerable<Project> IUnitTest.UnitTestsProjects => Solution.AllProjects.Where(project => project.Name.EndsWith(".Tests", StringComparison.OrdinalIgnoreCase));
 
 
     /// Support plugins are available for:

--- a/src/Candoumbe.Pipelines/Candoumbe.Pipelines.csproj
+++ b/src/Candoumbe.Pipelines/Candoumbe.Pipelines.csproj
@@ -14,4 +14,7 @@
   <ItemGroup>
     <PackageReference Include="Nuke.Common"/>
   </ItemGroup>
+  <ItemGroup>
+    <NukeSpecificationFiles Include=".\tools\Stryker\Stryker.json"/>
+  </ItemGroup>
 </Project>

--- a/src/Candoumbe.Pipelines/Candoumbe.Pipelines.csproj
+++ b/src/Candoumbe.Pipelines/Candoumbe.Pipelines.csproj
@@ -13,7 +13,4 @@
   <ItemGroup>
     <PackageReference Include="Nuke.Common"/>
   </ItemGroup>
-  <ItemGroup>
-    <NukeSpecificationFiles Include=".\tools\Stryker\Stryker.json"/>
-  </ItemGroup>
 </Project>

--- a/src/Candoumbe.Pipelines/Candoumbe.Pipelines.csproj
+++ b/src/Candoumbe.Pipelines/Candoumbe.Pipelines.csproj
@@ -3,6 +3,7 @@
   <Import Project="../../core.props"/>
   <PropertyGroup>
     <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+    <AppendTargetFrameworkToOutputPath>true</AppendTargetFrameworkToOutputPath>
     <Description>A Stater development kit to script your CI/CD using [Nuke](https://nuke.build).</Description>
     <PackageTags>build, pipeline, ci, workflow</PackageTags>
     <NukeBaseDirectory>$(MsBuildProjectDirectory)\tools\Stryker</NukeBaseDirectory>

--- a/src/Candoumbe.Pipelines/Candoumbe.Pipelines.csproj
+++ b/src/Candoumbe.Pipelines/Candoumbe.Pipelines.csproj
@@ -14,7 +14,4 @@
   <ItemGroup>
     <PackageReference Include="Nuke.Common"/>
   </ItemGroup>
-  <ItemGroup>
-    <NukeSpecificationFiles Include=".\tools\Stryker\Stryker.json"/>
-  </ItemGroup>
 </Project>

--- a/test/Candoumbe.Pipelines.Tests/Candoumbe.Pipelines.Tests.csproj
+++ b/test/Candoumbe.Pipelines.Tests/Candoumbe.Pipelines.Tests.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="../../core.props"/>
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions"/>
+    <PackageReference Include="Microsoft.NET.Test.Sdk"/>
+    <PackageReference Include="NSubstitute"/>
+    <PackageReference Include="xunit"/>
+    <PackageReference Include="xunit.runner.visualstudio">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../src/Candoumbe.Pipelines/Candoumbe.Pipelines.csproj"/>
+  </ItemGroup>
+
+</Project>

--- a/test/Candoumbe.Pipelines.Tests/ConfigurationTests.cs
+++ b/test/Candoumbe.Pipelines.Tests/ConfigurationTests.cs
@@ -1,0 +1,45 @@
+using Candoumbe.Pipelines.Components;
+using FluentAssertions;
+using Xunit;
+
+namespace Candoumbe.Pipelines.Tests;
+
+public class ConfigurationTests
+{
+    [Fact]
+    public void Given_DebugConfiguration_When_ConvertingToString_Then_ReturnsDebug()
+    {
+        // Arrange
+        Configuration configuration = Configuration.Debug;
+
+        // Act
+        string actual = configuration;
+
+        // Assert
+        actual.Should().Be("Debug");
+    }
+
+    [Fact]
+    public void Given_ReleaseConfiguration_When_ConvertingToString_Then_ReturnsRelease()
+    {
+        // Arrange
+        Configuration configuration = Configuration.Release;
+
+        // Act
+        string actual = configuration;
+
+        // Assert
+        actual.Should().Be("Release");
+    }
+
+    [Fact]
+    public void Given_DebugAndRelease_When_Comparing_Then_TheyAreDifferent()
+    {
+        // Arrange
+        Configuration debug = Configuration.Debug;
+        Configuration release = Configuration.Release;
+
+        // Act & Assert
+        debug.Should().NotBe(release);
+    }
+}

--- a/test/Candoumbe.Pipelines.Tests/DockerFileTests.cs
+++ b/test/Candoumbe.Pipelines.Tests/DockerFileTests.cs
@@ -1,0 +1,58 @@
+using Candoumbe.Pipelines.Components.Docker;
+using FluentAssertions;
+using Nuke.Common.IO;
+using Xunit;
+
+namespace Candoumbe.Pipelines.Tests;
+
+public class DockerFileTests
+{
+    [Fact]
+    public void Given_NoTagProvided_When_CreatingDockerFile_Then_TagDefaultsToLatest()
+    {
+        // Arrange & Act
+        var dockerFile = new DockerFile((AbsolutePath)"/app/Dockerfile", "my-image");
+
+        // Assert
+        dockerFile.Tag.Should().Be("latest");
+    }
+
+    [Fact]
+    public void Given_TagProvided_When_CreatingDockerFile_Then_TagUsesProvidedValue()
+    {
+        // Arrange
+        string expectedTag = "v1.0";
+
+        // Act
+        var dockerFile = new DockerFile((AbsolutePath)"/app/Dockerfile", "my-image", expectedTag);
+
+        // Assert
+        dockerFile.Tag.Should().Be(expectedTag);
+    }
+
+    [Fact]
+    public void Given_NameProvided_When_CreatingDockerFile_Then_NameIsSet()
+    {
+        // Arrange
+        string expectedName = "my-image";
+
+        // Act
+        var dockerFile = new DockerFile((AbsolutePath)"/app/Dockerfile", expectedName);
+
+        // Assert
+        dockerFile.Name.Should().Be(expectedName);
+    }
+
+    [Fact]
+    public void Given_PathProvided_When_CreatingDockerFile_Then_PathIsSet()
+    {
+        // Arrange
+        AbsolutePath expectedPath = (AbsolutePath)"/app/Dockerfile";
+
+        // Act
+        var dockerFile = new DockerFile(expectedPath, "my-image");
+
+        // Assert
+        dockerFile.Path.Should().Be(expectedPath);
+    }
+}

--- a/test/Candoumbe.Pipelines.Tests/DockerFileTests.cs
+++ b/test/Candoumbe.Pipelines.Tests/DockerFileTests.cs
@@ -11,7 +11,7 @@ public class DockerFileTests
     public void Given_NoTagProvided_When_CreatingDockerFile_Then_TagDefaultsToLatest()
     {
         // Arrange & Act
-        var dockerFile = new DockerFile((AbsolutePath)"/app/Dockerfile", "my-image");
+        DockerFile dockerFile = new ((AbsolutePath)"/app/Dockerfile", "my-image");
 
         // Assert
         dockerFile.Tag.Should().Be("latest");
@@ -24,7 +24,7 @@ public class DockerFileTests
         string expectedTag = "v1.0";
 
         // Act
-        var dockerFile = new DockerFile((AbsolutePath)"/app/Dockerfile", "my-image", expectedTag);
+        DockerFile dockerFile = new ((AbsolutePath)"/app/Dockerfile", "my-image", expectedTag);
 
         // Assert
         dockerFile.Tag.Should().Be(expectedTag);
@@ -37,7 +37,7 @@ public class DockerFileTests
         string expectedName = "my-image";
 
         // Act
-        var dockerFile = new DockerFile((AbsolutePath)"/app/Dockerfile", expectedName);
+        DockerFile dockerFile = new ((AbsolutePath)"/app/Dockerfile", expectedName);
 
         // Assert
         dockerFile.Name.Should().Be(expectedName);
@@ -50,7 +50,7 @@ public class DockerFileTests
         AbsolutePath expectedPath = (AbsolutePath)"/app/Dockerfile";
 
         // Act
-        var dockerFile = new DockerFile(expectedPath, "my-image");
+        DockerFile dockerFile = new (expectedPath, "my-image");
 
         // Assert
         dockerFile.Path.Should().Be(expectedPath);

--- a/test/Candoumbe.Pipelines.Tests/DotNetFormatterTests.cs
+++ b/test/Candoumbe.Pipelines.Tests/DotNetFormatterTests.cs
@@ -1,0 +1,47 @@
+using Candoumbe.Pipelines.Components.Formatting;
+using FluentAssertions;
+using Xunit;
+
+namespace Candoumbe.Pipelines.Tests;
+
+public class DotNetFormatterTests
+{
+    [Fact]
+    public void Given_AnalyzersFormatter_When_ConvertingToString_Then_ReturnsAnalyzers()
+    {
+        // Arrange
+        DotNetFormatter formatter = DotNetFormatter.Analyzers;
+
+        // Act
+        string actual = formatter;
+
+        // Assert
+        actual.Should().Be("Analyzers");
+    }
+
+    [Fact]
+    public void Given_StyleFormatter_When_ConvertingToString_Then_ReturnsStyle()
+    {
+        // Arrange
+        DotNetFormatter formatter = DotNetFormatter.Style;
+
+        // Act
+        string actual = formatter;
+
+        // Assert
+        actual.Should().Be("Style");
+    }
+
+    [Fact]
+    public void Given_WhitespaceFormatter_When_ConvertingToString_Then_ReturnsWhitespace()
+    {
+        // Arrange
+        DotNetFormatter formatter = DotNetFormatter.Whitespace;
+
+        // Act
+        string actual = formatter;
+
+        // Assert
+        actual.Should().Be("Whitespace");
+    }
+}

--- a/test/Candoumbe.Pipelines.Tests/ExtensionsTests.cs
+++ b/test/Candoumbe.Pipelines.Tests/ExtensionsTests.cs
@@ -1,0 +1,70 @@
+using Candoumbe.Pipelines.Components;
+using FluentAssertions;
+using Xunit;
+
+namespace Candoumbe.Pipelines.Tests;
+
+public class ExtensionsTests
+{
+    [Fact]
+    public void Given_NonNullObject_When_CallingWhenNotNull_Then_ConfiguratorIsApplied()
+    {
+        // Arrange
+        string settings = "initial";
+        string obj = "value";
+
+        // Act
+        string actual = settings.WhenNotNull(obj, (s, o) => s + "-" + o);
+
+        // Assert
+        actual.Should().Be("initial-value");
+    }
+
+    [Fact]
+    public void Given_NullObject_When_CallingWhenNotNull_Then_SettingsAreReturnedUnchanged()
+    {
+        // Arrange
+        string settings = "initial";
+        string obj = null;
+
+        // Act
+        string actual = settings.WhenNotNull(obj, (s, o) => s + "-" + o);
+
+        // Assert
+        actual.Should().Be("initial");
+    }
+
+    [Fact]
+    public void Given_NonNullNullableInt_When_CallingWhenNotNull_Then_BothArgumentsArePassedToConfigurator()
+    {
+        // Arrange
+        int baseValue = 10;
+        int? multiplier = 3;
+
+        // Act
+        int actual = baseValue.WhenNotNull(multiplier, (b, m) => b * m.Value);
+
+        // Assert
+        actual.Should().Be(30);
+    }
+
+    [Fact]
+    public void Given_NullNullableInt_When_CallingWhenNotNull_Then_ConfiguratorIsNotInvoked()
+    {
+        // Arrange
+        int baseValue = 10;
+        int? multiplier = null;
+        bool configuratorCalled = false;
+
+        // Act
+        int actual = baseValue.WhenNotNull(multiplier, (b, m) =>
+        {
+            configuratorCalled = true;
+            return b * m.Value;
+        });
+
+        // Assert
+        actual.Should().Be(10);
+        configuratorCalled.Should().BeFalse();
+    }
+}

--- a/test/Candoumbe.Pipelines.Tests/GitHubPushNugetConfigurationTests.cs
+++ b/test/Candoumbe.Pipelines.Tests/GitHubPushNugetConfigurationTests.cs
@@ -11,7 +11,7 @@ public class GitHubPushNugetConfigurationTests
     public void Given_ValidArguments_When_CreatingInstance_Then_NameIsGitHub()
     {
         // Arrange & Act
-        var config = new GitHubPushNugetConfiguration("github-token", new Uri("https://nuget.pkg.github.com/owner/index.json"));
+        GitHubPushNugetConfiguration config = new ("github-token", new Uri("https://nuget.pkg.github.com/owner/index.json"));
 
         // Assert
         config.Name.Should().Be("GitHub");
@@ -21,7 +21,7 @@ public class GitHubPushNugetConfigurationTests
     public void Given_NoCanBeUsedProvided_When_CreatingInstance_Then_CanBeUsedReturnsTrue()
     {
         // Arrange & Act
-        var config = new GitHubPushNugetConfiguration("github-token", new Uri("https://nuget.pkg.github.com/owner/index.json"));
+        GitHubPushNugetConfiguration config = new ("github-token", new Uri("https://nuget.pkg.github.com/owner/index.json"));
 
         // Assert
         config.CanBeUsed().Should().BeTrue();
@@ -31,7 +31,7 @@ public class GitHubPushNugetConfigurationTests
     public void Given_CanBeUsedReturnsFalse_When_CreatingInstance_Then_CanBeUsedReturnsFalse()
     {
         // Arrange & Act
-        var config = new GitHubPushNugetConfiguration("github-token", new Uri("https://nuget.pkg.github.com/owner/index.json"), () => false);
+        GitHubPushNugetConfiguration config = new ("github-token", new Uri("https://nuget.pkg.github.com/owner/index.json"), () => false);
 
         // Assert
         config.CanBeUsed().Should().BeFalse();
@@ -44,7 +44,7 @@ public class GitHubPushNugetConfigurationTests
         Uri uri = new Uri("https://nuget.pkg.github.com/owner/index.json");
 
         // Act
-        var config = new GitHubPushNugetConfiguration("github-token", uri);
+        GitHubPushNugetConfiguration config = new ("github-token", uri);
 
         // Assert
         config.Source.Should().Be(uri.ToString());
@@ -57,7 +57,7 @@ public class GitHubPushNugetConfigurationTests
         string expectedToken = "my-github-token";
 
         // Act
-        var config = new GitHubPushNugetConfiguration(expectedToken, new Uri("https://nuget.pkg.github.com/owner/index.json"));
+        GitHubPushNugetConfiguration config = new (expectedToken, new Uri("https://nuget.pkg.github.com/owner/index.json"));
 
         // Assert
         config.Key.Should().Be(expectedToken);

--- a/test/Candoumbe.Pipelines.Tests/GitHubPushNugetConfigurationTests.cs
+++ b/test/Candoumbe.Pipelines.Tests/GitHubPushNugetConfigurationTests.cs
@@ -1,0 +1,65 @@
+using System;
+using Candoumbe.Pipelines.Components.NuGet;
+using FluentAssertions;
+using Xunit;
+
+namespace Candoumbe.Pipelines.Tests;
+
+public class GitHubPushNugetConfigurationTests
+{
+    [Fact]
+    public void Given_ValidArguments_When_CreatingInstance_Then_NameIsGitHub()
+    {
+        // Arrange & Act
+        var config = new GitHubPushNugetConfiguration("github-token", new Uri("https://nuget.pkg.github.com/owner/index.json"));
+
+        // Assert
+        config.Name.Should().Be("GitHub");
+    }
+
+    [Fact]
+    public void Given_NoCanBeUsedProvided_When_CreatingInstance_Then_CanBeUsedReturnsTrue()
+    {
+        // Arrange & Act
+        var config = new GitHubPushNugetConfiguration("github-token", new Uri("https://nuget.pkg.github.com/owner/index.json"));
+
+        // Assert
+        config.CanBeUsed().Should().BeTrue();
+    }
+
+    [Fact]
+    public void Given_CanBeUsedReturnsFalse_When_CreatingInstance_Then_CanBeUsedReturnsFalse()
+    {
+        // Arrange & Act
+        var config = new GitHubPushNugetConfiguration("github-token", new Uri("https://nuget.pkg.github.com/owner/index.json"), () => false);
+
+        // Assert
+        config.CanBeUsed().Should().BeFalse();
+    }
+
+    [Fact]
+    public void Given_UriProvided_When_CreatingInstance_Then_SourceMatchesUri()
+    {
+        // Arrange
+        Uri uri = new Uri("https://nuget.pkg.github.com/owner/index.json");
+
+        // Act
+        var config = new GitHubPushNugetConfiguration("github-token", uri);
+
+        // Assert
+        config.Source.Should().Be(uri.ToString());
+    }
+
+    [Fact]
+    public void Given_GitHubTokenProvided_When_CreatingInstance_Then_KeyIsSet()
+    {
+        // Arrange
+        string expectedToken = "my-github-token";
+
+        // Act
+        var config = new GitHubPushNugetConfiguration(expectedToken, new Uri("https://nuget.pkg.github.com/owner/index.json"));
+
+        // Assert
+        config.Key.Should().Be(expectedToken);
+    }
+}

--- a/test/Candoumbe.Pipelines.Tests/IBenchmarkTests.cs
+++ b/test/Candoumbe.Pipelines.Tests/IBenchmarkTests.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+using Candoumbe.Pipelines.Components;
+using FluentAssertions;
+using Nuke.Common.IO;
+using Nuke.Common.ProjectModel;
+using Xunit;
+
+namespace Candoumbe.Pipelines.Tests;
+
+public class IBenchmarkTests
+{
+    [Fact]
+    public void Given_DefaultImplementation_When_AccessingBenchmarkResultDirectory_Then_ReturnsBenchmarksUnderArtifactsDirectory()
+    {
+        // Arrange
+        IBenchmark sut = new BenchmarkBuild();
+
+        // Act
+        AbsolutePath actual = sut.BenchmarkResultDirectory;
+
+        // Assert
+        actual.Should().Be(sut.ArtifactsDirectory / "benchmarks");
+    }
+
+    [Fact]
+    public void Given_DefaultImplementation_When_AccessingBenchmarkProjects_Then_ReturnsEmptyCollection()
+    {
+        // Arrange
+        IBenchmark sut = new BenchmarkBuild();
+
+        // Act
+        IEnumerable<Project> actual = sut.BenchmarkProjects;
+
+        // Assert
+        actual.Should().BeEmpty();
+    }
+}

--- a/test/Candoumbe.Pipelines.Tests/ICleanTests.cs
+++ b/test/Candoumbe.Pipelines.Tests/ICleanTests.cs
@@ -1,0 +1,49 @@
+using System.Collections.Generic;
+using Candoumbe.Pipelines.Components;
+using FluentAssertions;
+using Nuke.Common.IO;
+using Xunit;
+
+namespace Candoumbe.Pipelines.Tests;
+
+public class ICleanTests
+{
+    [Fact]
+    public void Given_DefaultImplementation_When_AccessingDirectoriesToDelete_Then_ReturnsEmptyCollection()
+    {
+        // Arrange
+        IClean sut = new CleanBuild();
+
+        // Act
+        IEnumerable<AbsolutePath> actual = sut.DirectoriesToDelete;
+
+        // Assert
+        actual.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Given_DefaultImplementation_When_AccessingDirectoriesToClean_Then_ReturnsEmptyCollection()
+    {
+        // Arrange
+        IClean sut = new CleanBuild();
+
+        // Act
+        IEnumerable<AbsolutePath> actual = sut.DirectoriesToClean;
+
+        // Assert
+        actual.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Given_DefaultImplementation_When_AccessingDirectoriesToEnsureExistence_Then_ReturnsEmptyCollection()
+    {
+        // Arrange
+        IClean sut = new CleanBuild();
+
+        // Act
+        IEnumerable<AbsolutePath> actual = sut.DirectoriesToEnsureExistence;
+
+        // Assert
+        actual.Should().BeEmpty();
+    }
+}

--- a/test/Candoumbe.Pipelines.Tests/IHaveArtifactsTests.cs
+++ b/test/Candoumbe.Pipelines.Tests/IHaveArtifactsTests.cs
@@ -1,0 +1,22 @@
+using Candoumbe.Pipelines.Components;
+using FluentAssertions;
+using Nuke.Common.IO;
+using Xunit;
+
+namespace Candoumbe.Pipelines.Tests;
+
+public class IHaveArtifactsTests
+{
+    [Fact]
+    public void Given_DefaultImplementation_When_AccessingArtifactsDirectory_Then_ReturnsArtifactsUnderOutputDirectory()
+    {
+        // Arrange
+        IHaveArtifacts sut = new ArtifactsBuild();
+
+        // Act
+        AbsolutePath actual = sut.ArtifactsDirectory;
+
+        // Assert
+        actual.Should().Be(sut.OutputDirectory / "artifacts");
+    }
+}

--- a/test/Candoumbe.Pipelines.Tests/IHaveChangeLogTests.cs
+++ b/test/Candoumbe.Pipelines.Tests/IHaveChangeLogTests.cs
@@ -1,0 +1,22 @@
+using Candoumbe.Pipelines.Components;
+using FluentAssertions;
+using Nuke.Common.IO;
+using Xunit;
+
+namespace Candoumbe.Pipelines.Tests;
+
+public class IHaveChangeLogTests
+{
+    [Fact]
+    public void Given_DefaultImplementation_When_AccessingChangeLogFile_Then_ReturnsChangelogMdUnderRootDirectory()
+    {
+        // Arrange
+        IHaveChangeLog sut = new ChangeLogBuild();
+
+        // Act
+        AbsolutePath actual = sut.ChangeLogFile;
+
+        // Assert
+        actual.Should().Be(sut.RootDirectory / "CHANGELOG.md");
+    }
+}

--- a/test/Candoumbe.Pipelines.Tests/IHaveCoverageTests.cs
+++ b/test/Candoumbe.Pipelines.Tests/IHaveCoverageTests.cs
@@ -1,0 +1,35 @@
+using Candoumbe.Pipelines.Components;
+using FluentAssertions;
+using Nuke.Common.IO;
+using Xunit;
+
+namespace Candoumbe.Pipelines.Tests;
+
+public class IHaveCoverageTests
+{
+    [Fact]
+    public void Given_DefaultImplementation_When_AccessingCoverageReportDirectory_Then_ReturnsCoverageReportUnderReportDirectory()
+    {
+        // Arrange
+        IHaveCoverage sut = new CoverageBuild();
+
+        // Act
+        AbsolutePath actual = sut.CoverageReportDirectory;
+
+        // Assert
+        actual.Should().Be(sut.ReportDirectory / "coverage-report");
+    }
+
+    [Fact]
+    public void Given_DefaultImplementation_When_AccessingCoverageReportHistoryDirectory_Then_ReturnsCoverageHistoryUnderReportDirectory()
+    {
+        // Arrange
+        IHaveCoverage sut = new CoverageBuild();
+
+        // Act
+        AbsolutePath actual = sut.CoverageReportHistoryDirectory;
+
+        // Assert
+        actual.Should().Be(sut.ReportDirectory / "coverage-history");
+    }
+}

--- a/test/Candoumbe.Pipelines.Tests/IHaveOutputDirectoryTests.cs
+++ b/test/Candoumbe.Pipelines.Tests/IHaveOutputDirectoryTests.cs
@@ -1,0 +1,35 @@
+using Candoumbe.Pipelines.Components;
+using FluentAssertions;
+using Nuke.Common.IO;
+using Xunit;
+
+namespace Candoumbe.Pipelines.Tests;
+
+public class IHaveOutputDirectoryTests
+{
+    [Fact]
+    public void Given_DefaultImplementation_When_AccessingOutputDirectoryName_Then_ReturnsOutput()
+    {
+        // Arrange
+        IHaveOutputDirectory sut = new OutputDirectoryBuild();
+
+        // Act
+        string actual = sut.OutputDirectoryName;
+
+        // Assert
+        actual.Should().Be("output");
+    }
+
+    [Fact]
+    public void Given_DefaultImplementation_When_AccessingOutputDirectory_Then_ReturnsOutputDirectoryNameUnderRootDirectory()
+    {
+        // Arrange
+        IHaveOutputDirectory sut = new OutputDirectoryBuild();
+
+        // Act
+        AbsolutePath actual = sut.OutputDirectory;
+
+        // Assert
+        actual.Should().Be(sut.RootDirectory / sut.OutputDirectoryName);
+    }
+}

--- a/test/Candoumbe.Pipelines.Tests/IHaveReportTests.cs
+++ b/test/Candoumbe.Pipelines.Tests/IHaveReportTests.cs
@@ -1,0 +1,22 @@
+using Candoumbe.Pipelines.Components;
+using FluentAssertions;
+using Nuke.Common.IO;
+using Xunit;
+
+namespace Candoumbe.Pipelines.Tests;
+
+public class IHaveReportTests
+{
+    [Fact]
+    public void Given_DefaultImplementation_When_AccessingReportDirectory_Then_ReturnsReportsUnderArtifactsDirectory()
+    {
+        // Arrange
+        IHaveReport sut = new ReportBuild();
+
+        // Act
+        AbsolutePath actual = sut.ReportDirectory;
+
+        // Assert
+        actual.Should().Be(sut.ArtifactsDirectory / "reports");
+    }
+}

--- a/test/Candoumbe.Pipelines.Tests/IHaveSourceDirectoryTests.cs
+++ b/test/Candoumbe.Pipelines.Tests/IHaveSourceDirectoryTests.cs
@@ -1,0 +1,22 @@
+using Candoumbe.Pipelines.Components;
+using FluentAssertions;
+using Nuke.Common.IO;
+using Xunit;
+
+namespace Candoumbe.Pipelines.Tests;
+
+public class IHaveSourceDirectoryTests
+{
+    [Fact]
+    public void Given_DefaultImplementation_When_AccessingSourceDirectory_Then_ReturnsSrcUnderRootDirectory()
+    {
+        // Arrange
+        IHaveSourceDirectory sut = new SourceDirectoryBuild();
+
+        // Act
+        AbsolutePath actual = sut.SourceDirectory;
+
+        // Assert
+        actual.Should().Be(sut.RootDirectory / "src");
+    }
+}

--- a/test/Candoumbe.Pipelines.Tests/IHaveTestDirectoryTests.cs
+++ b/test/Candoumbe.Pipelines.Tests/IHaveTestDirectoryTests.cs
@@ -1,0 +1,22 @@
+using Candoumbe.Pipelines.Components;
+using FluentAssertions;
+using Nuke.Common.IO;
+using Xunit;
+
+namespace Candoumbe.Pipelines.Tests;
+
+public class IHaveTestDirectoryTests
+{
+    [Fact]
+    public void Given_DefaultImplementation_When_AccessingTestDirectory_Then_ReturnsTestUnderRootDirectory()
+    {
+        // Arrange
+        IHaveTestDirectory sut = new TestDirectoryBuild();
+
+        // Act
+        AbsolutePath actual = sut.TestDirectory;
+
+        // Assert
+        actual.Should().Be(sut.RootDirectory / "test");
+    }
+}

--- a/test/Candoumbe.Pipelines.Tests/IHaveTestsTests.cs
+++ b/test/Candoumbe.Pipelines.Tests/IHaveTestsTests.cs
@@ -1,0 +1,35 @@
+using Candoumbe.Pipelines.Components;
+using FluentAssertions;
+using Nuke.Common.IO;
+using Xunit;
+
+namespace Candoumbe.Pipelines.Tests;
+
+public class IHaveTestsTests
+{
+    [Fact]
+    public void Given_DefaultImplementation_When_AccessingTestResultDirectory_Then_ReturnsTestsResultsUnderArtifactsDirectory()
+    {
+        // Arrange
+        IHaveTests sut = new TestResultsBuild();
+
+        // Act
+        AbsolutePath actual = sut.TestResultDirectory;
+
+        // Assert
+        actual.Should().Be(sut.ArtifactsDirectory / "tests-results");
+    }
+
+    [Fact]
+    public void Given_TestResultDirectoryNameConstant_When_AccessingValue_Then_ReturnsTestsResults()
+    {
+        // Arrange
+        string expected = "tests-results";
+
+        // Act
+        string actual = IHaveTests.TestResultDirectoryName;
+
+        // Assert
+        actual.Should().Be(expected);
+    }
+}

--- a/test/Candoumbe.Pipelines.Tests/IIntegrationTestTests.cs
+++ b/test/Candoumbe.Pipelines.Tests/IIntegrationTestTests.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+using Candoumbe.Pipelines.Components;
+using FluentAssertions;
+using Nuke.Common.IO;
+using Nuke.Common.ProjectModel;
+using Xunit;
+
+namespace Candoumbe.Pipelines.Tests;
+
+public class IIntegrationTestTests
+{
+    [Fact]
+    public void Given_DefaultImplementation_When_AccessingIntegrationTestResultsDirectory_Then_ReturnsIntegrationTestsUnderTestResultDirectory()
+    {
+        // Arrange
+        IIntegrationTest sut = new IntegrationTestBuild();
+
+        // Act
+        AbsolutePath actual = sut.IntegrationTestResultsDirectory;
+
+        // Assert
+        actual.Should().Be(sut.TestResultDirectory / "integration-tests");
+    }
+
+    [Fact]
+    public void Given_DefaultImplementation_When_AccessingIntegrationTestsProjects_Then_ReturnsEmptyCollection()
+    {
+        // Arrange
+        IIntegrationTest sut = new IntegrationTestBuild();
+
+        // Act
+        IEnumerable<Project> actual = sut.IntegrationTestsProjects;
+
+        // Assert
+        actual.Should().BeEmpty();
+    }
+}

--- a/test/Candoumbe.Pipelines.Tests/IMutationTestTests.cs
+++ b/test/Candoumbe.Pipelines.Tests/IMutationTestTests.cs
@@ -1,0 +1,36 @@
+using System.Collections.Generic;
+using Candoumbe.Pipelines.Components;
+using FluentAssertions;
+using Nuke.Common.IO;
+using Xunit;
+
+namespace Candoumbe.Pipelines.Tests;
+
+public class IMutationTestTests
+{
+    [Fact]
+    public void Given_DefaultImplementation_When_AccessingMutationTestResultDirectory_Then_ReturnsMutationTestsUnderTestResultDirectory()
+    {
+        // Arrange
+        IMutationTest sut = new MutationTestBuild();
+
+        // Act
+        AbsolutePath actual = sut.MutationTestResultDirectory;
+
+        // Assert
+        actual.Should().Be(sut.TestResultDirectory / "mutation-tests");
+    }
+
+    [Fact]
+    public void Given_DefaultImplementation_When_AccessingMutationTestsProjects_Then_ReturnsEmptyCollection()
+    {
+        // Arrange
+        IMutationTest sut = new MutationTestBuild();
+
+        // Act
+        IEnumerable<MutationProjectConfiguration> actual = sut.MutationTestsProjects;
+
+        // Assert
+        actual.Should().BeEmpty();
+    }
+}

--- a/test/Candoumbe.Pipelines.Tests/IPackTests.cs
+++ b/test/Candoumbe.Pipelines.Tests/IPackTests.cs
@@ -1,0 +1,22 @@
+using Candoumbe.Pipelines.Components;
+using FluentAssertions;
+using Nuke.Common.IO;
+using Xunit;
+
+namespace Candoumbe.Pipelines.Tests;
+
+public class IPackTests
+{
+    [Fact]
+    public void Given_DefaultImplementation_When_AccessingPackagesDirectory_Then_ReturnsPackagesUnderArtifactsDirectory()
+    {
+        // Arrange
+        IPack sut = new PackBuild();
+
+        // Act
+        AbsolutePath actual = sut.PackagesDirectory;
+
+        // Assert
+        actual.Should().Be(sut.ArtifactsDirectory / "packages");
+    }
+}

--- a/test/Candoumbe.Pipelines.Tests/IReportIntegrationTestCoverageTests.cs
+++ b/test/Candoumbe.Pipelines.Tests/IReportIntegrationTestCoverageTests.cs
@@ -1,0 +1,61 @@
+using Candoumbe.Pipelines.Components;
+using FluentAssertions;
+using Nuke.Common.IO;
+using Xunit;
+
+namespace Candoumbe.Pipelines.Tests;
+
+public class IReportIntegrationTestCoverageTests
+{
+    [Fact]
+    public void Given_DefaultImplementation_When_AccessingIntegrationTestCoverageReportDirectory_Then_ReturnsExpectedPath()
+    {
+        // Arrange
+        IReportIntegrationTestCoverage sut = new ReportIntegrationTestCoverageBuild();
+
+        // Act
+        AbsolutePath actual = sut.IntegrationTestCoverageReportDirectory;
+
+        // Assert
+        actual.Should().Be(sut.CoverageReportDirectory / "integration-tests-coverage");
+    }
+
+    [Fact]
+    public void Given_DefaultImplementation_When_AccessingIntegrationTestCoverageReportHistoryDirectory_Then_ReturnsExpectedPath()
+    {
+        // Arrange
+        IReportIntegrationTestCoverage sut = new ReportIntegrationTestCoverageBuild();
+
+        // Act
+        AbsolutePath actual = sut.IntegrationTestCoverageReportHistoryDirectory;
+
+        // Assert
+        actual.Should().Be(sut.CoverageReportHistoryDirectory / "integration-tests-coverage-history");
+    }
+
+    [Fact]
+    public void Given_DefaultImplementation_When_AccessingCodeCoverageReportArtifactName_Then_ReturnsIntegrationTestsCoverage()
+    {
+        // Arrange
+        IReportIntegrationTestCoverage sut = new ReportIntegrationTestCoverageBuild();
+
+        // Act
+        string actual = sut.CodeCoverageReportArtifactName;
+
+        // Assert
+        actual.Should().Be("integration-tests-coverage");
+    }
+
+    [Fact]
+    public void Given_DefaultImplementation_When_AccessingCodeCoverageHistoryReportArtifactName_Then_ReturnsIntegrationTestsCoverageHistory()
+    {
+        // Arrange
+        IReportIntegrationTestCoverage sut = new ReportIntegrationTestCoverageBuild();
+
+        // Act
+        string actual = sut.CodeCoverageHistoryReportArtifactName;
+
+        // Assert
+        actual.Should().Be("integration-tests-coverage-history");
+    }
+}

--- a/test/Candoumbe.Pipelines.Tests/IReportUnitTestCoverageTests.cs
+++ b/test/Candoumbe.Pipelines.Tests/IReportUnitTestCoverageTests.cs
@@ -1,0 +1,61 @@
+using Candoumbe.Pipelines.Components;
+using FluentAssertions;
+using Nuke.Common.IO;
+using Xunit;
+
+namespace Candoumbe.Pipelines.Tests;
+
+public class IReportUnitTestCoverageTests
+{
+    [Fact]
+    public void Given_DefaultImplementation_When_AccessingUnitTestCoverageReportDirectory_Then_ReturnsExpectedPath()
+    {
+        // Arrange
+        IReportUnitTestCoverage sut = new ReportUnitTestCoverageBuild();
+
+        // Act
+        AbsolutePath actual = sut.UnitTestCoverageReportDirectory;
+
+        // Assert
+        actual.Should().Be(sut.CoverageReportDirectory / "unit-tests-coverage");
+    }
+
+    [Fact]
+    public void Given_DefaultImplementation_When_AccessingUnitTestCoverageReportHistoryDirectory_Then_ReturnsExpectedPath()
+    {
+        // Arrange
+        IReportUnitTestCoverage sut = new ReportUnitTestCoverageBuild();
+
+        // Act
+        AbsolutePath actual = sut.UnitTestCoverageReportHistoryDirectory;
+
+        // Assert
+        actual.Should().Be(sut.CoverageReportHistoryDirectory / "unit-tests-coverage-history");
+    }
+
+    [Fact]
+    public void Given_DefaultImplementation_When_AccessingCodeCoverageReportArtifactName_Then_ReturnsUnitTestsCoverage()
+    {
+        // Arrange
+        IReportUnitTestCoverage sut = new ReportUnitTestCoverageBuild();
+
+        // Act
+        string actual = sut.CodeCoverageReportArtifactName;
+
+        // Assert
+        actual.Should().Be("unit-tests-coverage");
+    }
+
+    [Fact]
+    public void Given_DefaultImplementation_When_AccessingCodeCoverageHistoryReportArtifactName_Then_ReturnsUnitTestsCoverageHistory()
+    {
+        // Arrange
+        IReportUnitTestCoverage sut = new ReportUnitTestCoverageBuild();
+
+        // Act
+        string actual = sut.CodeCoverageHistoryReportArtifactName;
+
+        // Assert
+        actual.Should().Be("unit-tests-coverage-history");
+    }
+}

--- a/test/Candoumbe.Pipelines.Tests/IUnitTestTests.cs
+++ b/test/Candoumbe.Pipelines.Tests/IUnitTestTests.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+using Candoumbe.Pipelines.Components;
+using FluentAssertions;
+using Nuke.Common.IO;
+using Nuke.Common.ProjectModel;
+using Xunit;
+
+namespace Candoumbe.Pipelines.Tests;
+
+public class IUnitTestTests
+{
+    [Fact]
+    public void Given_DefaultImplementation_When_AccessingUnitTestResultsDirectory_Then_ReturnsUnitTestsUnderTestResultDirectory()
+    {
+        // Arrange
+        IUnitTest sut = new UnitTestBuild();
+
+        // Act
+        AbsolutePath actual = sut.UnitTestResultsDirectory;
+
+        // Assert
+        actual.Should().Be(sut.TestResultDirectory / "unit-tests");
+    }
+
+    [Fact]
+    public void Given_DefaultImplementation_When_AccessingUnitTestsProjects_Then_ReturnsEmptyCollection()
+    {
+        // Arrange
+        IUnitTest sut = new UnitTestBuild();
+
+        // Act
+        IEnumerable<Project> actual = sut.UnitTestsProjects;
+
+        // Assert
+        actual.Should().BeEmpty();
+    }
+}

--- a/test/Candoumbe.Pipelines.Tests/NugetPushConfigurationTests.cs
+++ b/test/Candoumbe.Pipelines.Tests/NugetPushConfigurationTests.cs
@@ -1,0 +1,78 @@
+using System;
+using Candoumbe.Pipelines.Components.NuGet;
+using FluentAssertions;
+using Xunit;
+
+namespace Candoumbe.Pipelines.Tests;
+
+public class NugetPushConfigurationTests
+{
+    [Fact]
+    public void Given_StringSourceConstructor_When_CreatingInstance_Then_NameIsNuget()
+    {
+        // Arrange & Act
+        var config = new NugetPushConfiguration("api-key", "https://api.nuget.org/v3/index.json");
+
+        // Assert
+        config.Name.Should().Be("Nuget");
+    }
+
+    [Fact]
+    public void Given_NoCanBeUsedProvided_When_CreatingInstance_Then_CanBeUsedReturnsTrue()
+    {
+        // Arrange & Act
+        var config = new NugetPushConfiguration("api-key", "https://api.nuget.org/v3/index.json");
+
+        // Assert
+        config.CanBeUsed().Should().BeTrue();
+    }
+
+    [Fact]
+    public void Given_UriSourceConstructor_When_CreatingInstance_Then_SourceMatchesUri()
+    {
+        // Arrange
+        Uri uri = new Uri("https://api.nuget.org/v3/index.json");
+
+        // Act
+        var config = new NugetPushConfiguration("api-key", uri);
+
+        // Assert
+        config.Source.Should().Be(uri.ToString());
+    }
+
+    [Fact]
+    public void Given_StringSourceConstructor_When_CreatingInstance_Then_SourceMatchesString()
+    {
+        // Arrange
+        string source = "https://api.nuget.org/v3/index.json";
+
+        // Act
+        var config = new NugetPushConfiguration("api-key", source);
+
+        // Assert
+        config.Source.Should().Be(source);
+    }
+
+    [Fact]
+    public void Given_CanBeUsedReturnsFalse_When_CreatingInstance_Then_CanBeUsedReturnsFalse()
+    {
+        // Arrange & Act
+        var config = new NugetPushConfiguration("api-key", "https://api.nuget.org/v3/index.json", () => false);
+
+        // Assert
+        config.CanBeUsed().Should().BeFalse();
+    }
+
+    [Fact]
+    public void Given_ApiKeyProvided_When_CreatingInstance_Then_KeyIsSet()
+    {
+        // Arrange
+        string expectedKey = "my-api-key";
+
+        // Act
+        var config = new NugetPushConfiguration(expectedKey, "https://api.nuget.org/v3/index.json");
+
+        // Assert
+        config.Key.Should().Be(expectedKey);
+    }
+}

--- a/test/Candoumbe.Pipelines.Tests/NugetPushConfigurationTests.cs
+++ b/test/Candoumbe.Pipelines.Tests/NugetPushConfigurationTests.cs
@@ -11,7 +11,7 @@ public class NugetPushConfigurationTests
     public void Given_StringSourceConstructor_When_CreatingInstance_Then_NameIsNuget()
     {
         // Arrange & Act
-        var config = new NugetPushConfiguration("api-key", "https://api.nuget.org/v3/index.json");
+        NugetPushConfiguration config = new ("api-key", "https://api.nuget.org/v3/index.json");
 
         // Assert
         config.Name.Should().Be("Nuget");
@@ -21,7 +21,7 @@ public class NugetPushConfigurationTests
     public void Given_NoCanBeUsedProvided_When_CreatingInstance_Then_CanBeUsedReturnsTrue()
     {
         // Arrange & Act
-        var config = new NugetPushConfiguration("api-key", "https://api.nuget.org/v3/index.json");
+        NugetPushConfiguration config = new ("api-key", "https://api.nuget.org/v3/index.json");
 
         // Assert
         config.CanBeUsed().Should().BeTrue();
@@ -34,7 +34,7 @@ public class NugetPushConfigurationTests
         Uri uri = new Uri("https://api.nuget.org/v3/index.json");
 
         // Act
-        var config = new NugetPushConfiguration("api-key", uri);
+        NugetPushConfiguration config = new ("api-key", uri);
 
         // Assert
         config.Source.Should().Be(uri.ToString());
@@ -47,7 +47,7 @@ public class NugetPushConfigurationTests
         string source = "https://api.nuget.org/v3/index.json";
 
         // Act
-        var config = new NugetPushConfiguration("api-key", source);
+        NugetPushConfiguration config = new ("api-key", source);
 
         // Assert
         config.Source.Should().Be(source);
@@ -57,7 +57,7 @@ public class NugetPushConfigurationTests
     public void Given_CanBeUsedReturnsFalse_When_CreatingInstance_Then_CanBeUsedReturnsFalse()
     {
         // Arrange & Act
-        var config = new NugetPushConfiguration("api-key", "https://api.nuget.org/v3/index.json", () => false);
+        NugetPushConfiguration config = new ("api-key", "https://api.nuget.org/v3/index.json", () => false);
 
         // Assert
         config.CanBeUsed().Should().BeFalse();
@@ -70,7 +70,7 @@ public class NugetPushConfigurationTests
         string expectedKey = "my-api-key";
 
         // Act
-        var config = new NugetPushConfiguration(expectedKey, "https://api.nuget.org/v3/index.json");
+        NugetPushConfiguration config = new (expectedKey, "https://api.nuget.org/v3/index.json");
 
         // Assert
         config.Key.Should().Be(expectedKey);

--- a/test/Candoumbe.Pipelines.Tests/PathHierarchyTests.cs
+++ b/test/Candoumbe.Pipelines.Tests/PathHierarchyTests.cs
@@ -1,0 +1,167 @@
+using Candoumbe.Pipelines.Components;
+using FluentAssertions;
+using Nuke.Common.IO;
+using Xunit;
+
+namespace Candoumbe.Pipelines.Tests;
+
+/// <summary>
+/// Tests that validate the full path hierarchy produced by composing multiple infrastructure interfaces.
+/// </summary>
+public class PathHierarchyTests
+{
+    [Fact]
+    public void Given_DefaultComposition_When_AccessingTestResultDirectory_Then_FollowsFullPathConvention()
+    {
+        // Arrange
+        IHaveTests sut = new TestResultsBuild();
+        AbsolutePath root = sut.RootDirectory;
+
+        // Act
+        AbsolutePath actual = sut.TestResultDirectory;
+
+        // Assert
+        actual.Should().Be(root / "output" / "artifacts" / "tests-results");
+    }
+
+    [Fact]
+    public void Given_DefaultComposition_When_AccessingReportDirectory_Then_FollowsFullPathConvention()
+    {
+        // Arrange
+        IHaveReport sut = new ReportBuild();
+        AbsolutePath root = sut.RootDirectory;
+
+        // Act
+        AbsolutePath actual = sut.ReportDirectory;
+
+        // Assert
+        actual.Should().Be(root / "output" / "artifacts" / "reports");
+    }
+
+    [Fact]
+    public void Given_DefaultComposition_When_AccessingCoverageReportDirectory_Then_FollowsFullPathConvention()
+    {
+        // Arrange
+        IHaveCoverage sut = new CoverageBuild();
+        AbsolutePath root = sut.RootDirectory;
+
+        // Act
+        AbsolutePath actual = sut.CoverageReportDirectory;
+
+        // Assert
+        actual.Should().Be(root / "output" / "artifacts" / "reports" / "coverage-report");
+    }
+
+    [Fact]
+    public void Given_DefaultComposition_When_AccessingCoverageHistoryDirectory_Then_FollowsFullPathConvention()
+    {
+        // Arrange
+        IHaveCoverage sut = new CoverageBuild();
+        AbsolutePath root = sut.RootDirectory;
+
+        // Act
+        AbsolutePath actual = sut.CoverageReportHistoryDirectory;
+
+        // Assert
+        actual.Should().Be(root / "output" / "artifacts" / "reports" / "coverage-history");
+    }
+
+    [Fact]
+    public void Given_DefaultComposition_When_AccessingPackagesDirectory_Then_FollowsFullPathConvention()
+    {
+        // Arrange
+        IPack sut = new PackBuild();
+        AbsolutePath root = sut.RootDirectory;
+
+        // Act
+        AbsolutePath actual = sut.PackagesDirectory;
+
+        // Assert
+        actual.Should().Be(root / "output" / "artifacts" / "packages");
+    }
+
+    [Fact]
+    public void Given_DefaultComposition_When_AccessingUnitTestResultsDirectory_Then_FollowsFullPathConvention()
+    {
+        // Arrange
+        IUnitTest sut = new UnitTestBuild();
+        AbsolutePath root = sut.RootDirectory;
+
+        // Act
+        AbsolutePath actual = sut.UnitTestResultsDirectory;
+
+        // Assert
+        actual.Should().Be(root / "output" / "artifacts" / "tests-results" / "unit-tests");
+    }
+
+    [Fact]
+    public void Given_DefaultComposition_When_AccessingIntegrationTestResultsDirectory_Then_FollowsFullPathConvention()
+    {
+        // Arrange
+        IIntegrationTest sut = new IntegrationTestBuild();
+        AbsolutePath root = sut.RootDirectory;
+
+        // Act
+        AbsolutePath actual = sut.IntegrationTestResultsDirectory;
+
+        // Assert
+        actual.Should().Be(root / "output" / "artifacts" / "tests-results" / "integration-tests");
+    }
+
+    [Fact]
+    public void Given_DefaultComposition_When_AccessingMutationTestResultDirectory_Then_FollowsFullPathConvention()
+    {
+        // Arrange
+        IMutationTest sut = new MutationTestBuild();
+        AbsolutePath root = sut.RootDirectory;
+
+        // Act
+        AbsolutePath actual = sut.MutationTestResultDirectory;
+
+        // Assert
+        actual.Should().Be(root / "output" / "artifacts" / "tests-results" / "mutation-tests");
+    }
+
+    [Fact]
+    public void Given_DefaultComposition_When_AccessingBenchmarkResultDirectory_Then_FollowsFullPathConvention()
+    {
+        // Arrange
+        IBenchmark sut = new BenchmarkBuild();
+        AbsolutePath root = sut.RootDirectory;
+
+        // Act
+        AbsolutePath actual = sut.BenchmarkResultDirectory;
+
+        // Assert
+        actual.Should().Be(root / "output" / "artifacts" / "benchmarks");
+    }
+
+    [Fact]
+    public void Given_DefaultComposition_When_AccessingUnitTestCoverageReportDirectory_Then_FollowsFullPathConvention()
+    {
+        // Arrange
+        IReportUnitTestCoverage sut = new ReportUnitTestCoverageBuild();
+        AbsolutePath root = sut.RootDirectory;
+
+        // Act
+        AbsolutePath actual = sut.UnitTestCoverageReportDirectory;
+
+        // Assert
+        actual.Should().Be(root / "output" / "artifacts" / "reports" / "coverage-report" / "unit-tests-coverage");
+    }
+
+    [Fact]
+    public void Given_DefaultComposition_When_AccessingIntegrationTestCoverageReportDirectory_Then_FollowsFullPathConvention()
+    {
+        // Arrange
+        IReportIntegrationTestCoverage sut = new ReportIntegrationTestCoverageBuild();
+        AbsolutePath root = sut.RootDirectory;
+
+        // Act
+        AbsolutePath actual = sut.IntegrationTestCoverageReportDirectory;
+
+        // Assert
+        actual.Should().Be(root / "output" / "artifacts" / "reports" / "coverage-report" / "integration-tests-coverage");
+    }
+}
+

--- a/test/Candoumbe.Pipelines.Tests/PushDockerImageConfigurationTests.cs
+++ b/test/Candoumbe.Pipelines.Tests/PushDockerImageConfigurationTests.cs
@@ -14,7 +14,7 @@ public class PushDockerImageConfigurationTests
         Uri expectedRegistry = new Uri("https://registry.hub.docker.com");
 
         // Act
-        var config = new PushDockerImageConfiguration(expectedRegistry);
+        PushDockerImageConfiguration config = new (expectedRegistry);
 
         // Assert
         config.Registry.Should().Be(expectedRegistry);
@@ -24,7 +24,7 @@ public class PushDockerImageConfigurationTests
     public void Given_NoLoginSettingsProvided_When_CreatingInstance_Then_LoginSettingsIsNull()
     {
         // Arrange & Act
-        var config = new PushDockerImageConfiguration(new Uri("https://registry.hub.docker.com"));
+        PushDockerImageConfiguration config = new (new Uri("https://registry.hub.docker.com"));
 
         // Assert
         config.LoginSettings.Should().BeNull();

--- a/test/Candoumbe.Pipelines.Tests/PushDockerImageConfigurationTests.cs
+++ b/test/Candoumbe.Pipelines.Tests/PushDockerImageConfigurationTests.cs
@@ -1,0 +1,32 @@
+using System;
+using Candoumbe.Pipelines.Components.Docker;
+using FluentAssertions;
+using Xunit;
+
+namespace Candoumbe.Pipelines.Tests;
+
+public class PushDockerImageConfigurationTests
+{
+    [Fact]
+    public void Given_RegistryProvided_When_CreatingInstance_Then_RegistryIsSet()
+    {
+        // Arrange
+        Uri expectedRegistry = new Uri("https://registry.hub.docker.com");
+
+        // Act
+        var config = new PushDockerImageConfiguration(expectedRegistry);
+
+        // Assert
+        config.Registry.Should().Be(expectedRegistry);
+    }
+
+    [Fact]
+    public void Given_NoLoginSettingsProvided_When_CreatingInstance_Then_LoginSettingsIsNull()
+    {
+        // Arrange & Act
+        var config = new PushDockerImageConfiguration(new Uri("https://registry.hub.docker.com"));
+
+        // Assert
+        config.LoginSettings.Should().BeNull();
+    }
+}

--- a/test/Candoumbe.Pipelines.Tests/TestBuild.cs
+++ b/test/Candoumbe.Pipelines.Tests/TestBuild.cs
@@ -1,0 +1,63 @@
+using Candoumbe.Pipelines.Components;
+using Nuke.Common;
+
+namespace Candoumbe.Pipelines.Tests;
+
+/// <summary>
+/// Build stub that implements all the component interfaces for testing default implementations.
+/// Inherits from <see cref="NukeBuild"/> to get all the internal <see cref="INukeBuild"/> members.
+/// </summary>
+internal class SourceDirectoryBuild : NukeBuild, IHaveSourceDirectory;
+
+internal class OutputDirectoryBuild : NukeBuild, IHaveOutputDirectory;
+
+internal class ArtifactsBuild : NukeBuild, IHaveArtifacts;
+
+internal class TestDirectoryBuild : NukeBuild, IHaveTestDirectory;
+
+internal class TestResultsBuild : NukeBuild, IHaveTests;
+
+internal class ReportBuild : NukeBuild, IHaveReport;
+
+internal class CoverageBuild : NukeBuild, IHaveCoverage;
+
+internal class ChangeLogBuild : NukeBuild, IHaveChangeLog;
+
+internal class CleanBuild : NukeBuild, IClean;
+
+internal class PackBuild : NukeBuild, IPack
+{
+    public System.Collections.Generic.IEnumerable<Nuke.Common.IO.AbsolutePath> PackableProjects => [];
+}
+
+internal class UnitTestBuild : NukeBuild, IUnitTest
+{
+    public System.Collections.Generic.IEnumerable<Nuke.Common.ProjectModel.Project> UnitTestsProjects => [];
+}
+
+internal class IntegrationTestBuild : NukeBuild, IIntegrationTest
+{
+    public System.Collections.Generic.IEnumerable<Nuke.Common.ProjectModel.Project> IntegrationTestsProjects => [];
+}
+
+internal class MutationTestBuild : NukeBuild, IMutationTest
+{
+    public System.Collections.Generic.IEnumerable<MutationProjectConfiguration> MutationTestsProjects => [];
+}
+
+internal class BenchmarkBuild : NukeBuild, IBenchmark
+{
+    public System.Collections.Generic.IEnumerable<Nuke.Common.ProjectModel.Project> BenchmarkProjects => [];
+}
+
+internal class ReportUnitTestCoverageBuild : NukeBuild, IReportUnitTestCoverage
+{
+    public bool ReportToCodeCov => false;
+    public System.Collections.Generic.IEnumerable<Nuke.Common.ProjectModel.Project> UnitTestsProjects => [];
+}
+
+internal class ReportIntegrationTestCoverageBuild : NukeBuild, IReportIntegrationTestCoverage
+{
+    public bool ReportToCodeCov => false;
+    public System.Collections.Generic.IEnumerable<Nuke.Common.ProjectModel.Project> IntegrationTestsProjects => [];
+}


### PR DESCRIPTION
### 🧹 Housekeeping

- Add unit-tests for components
- Remove NukeSpecificationFiles directive in order to prevent builds from trying to override existing `Stryker.Generated.cs` file