### PR TITLE
chore(deps): replace `FluentAssertions` with `AwesomeAssertions`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### 🧹 Housekeeping
 - Fix imports ordering
+- Replace `FluentAssertions` with `AwesomeAssertions`
 
 ## [3.0.1] / 2026-07-15
 ### 🚨 Fixes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -376,7 +376,7 @@ public interface ICompile : IRestore, IFormat, IClean { ... }  // Too many hard 
 ### Framework
 
 - **xUnit** for test framework
-- **FluentAssertions** for assertions
+- **AwesomeAssertions** for assertions
 - **NSubstitute** for mocking
 
 ### Test naming convention
@@ -463,13 +463,13 @@ This project uses **Central Package Management**. All package versions are defin
 
 ```xml
 <!-- ✅ DO — add version in Directory.Packages.props -->
-<PackageVersion Include="FluentAssertions" Version="8.3.0"/>
+<PackageVersion Include="AwesomeAssertions" Version="8.3.0"/>
 
 <!-- ✅ DO — reference without version in .csproj -->
-<PackageReference Include="FluentAssertions"/>
+<PackageReference Include="AwesomeAssertions"/>
 
 <!-- ❌ DON'T — specify version in .csproj files -->
-<PackageReference Include="FluentAssertions" Version="8.3.0"/>
+<PackageReference Include="AwesomeAssertions" Version="8.3.0"/>
 ```
 
 ---

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -19,7 +19,7 @@
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.300"/>
   </ItemGroup>
   <ItemGroup Condition="'$(IsTestProject)' == 'true'">
-    <PackageVersion Include="FluentAssertions" Version="8.3.0"/>
+    <PackageVersion Include="AwesomeAssertions" Version="9.6.0"/>
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0"/>
     <PackageVersion Include="NSubstitute" Version="6.2.0"/>
     <PackageVersion Include="xunit" Version="2.9.3"/>

--- a/test/Candoumbe.Pipelines.Tests/Candoumbe.Pipelines.Tests.csproj
+++ b/test/Candoumbe.Pipelines.Tests/Candoumbe.Pipelines.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions"/>
+    <PackageReference Include="AwesomeAssertions"/>
     <PackageReference Include="Microsoft.NET.Test.Sdk"/>
     <PackageReference Include="NSubstitute"/>
     <PackageReference Include="xunit"/>

--- a/test/Candoumbe.Pipelines.Tests/ConfigurationTests.cs
+++ b/test/Candoumbe.Pipelines.Tests/ConfigurationTests.cs
@@ -1,5 +1,5 @@
+using AwesomeAssertions;
 using Candoumbe.Pipelines.Components;
-using FluentAssertions;
 using Xunit;
 
 namespace Candoumbe.Pipelines.Tests;

--- a/test/Candoumbe.Pipelines.Tests/DockerFileTests.cs
+++ b/test/Candoumbe.Pipelines.Tests/DockerFileTests.cs
@@ -1,5 +1,5 @@
+using AwesomeAssertions;
 using Candoumbe.Pipelines.Components.Docker;
-using FluentAssertions;
 using Fallout.Common.IO;
 using Xunit;
 

--- a/test/Candoumbe.Pipelines.Tests/DotNetFormatterTests.cs
+++ b/test/Candoumbe.Pipelines.Tests/DotNetFormatterTests.cs
@@ -1,5 +1,5 @@
+using AwesomeAssertions;
 using Candoumbe.Pipelines.Components.Formatting;
-using FluentAssertions;
 using Xunit;
 
 namespace Candoumbe.Pipelines.Tests;

--- a/test/Candoumbe.Pipelines.Tests/ExtensionsTests.cs
+++ b/test/Candoumbe.Pipelines.Tests/ExtensionsTests.cs
@@ -1,5 +1,5 @@
+using AwesomeAssertions;
 using Candoumbe.Pipelines.Components;
-using FluentAssertions;
 using Xunit;
 
 namespace Candoumbe.Pipelines.Tests;

--- a/test/Candoumbe.Pipelines.Tests/GitHubPushNugetConfigurationTests.cs
+++ b/test/Candoumbe.Pipelines.Tests/GitHubPushNugetConfigurationTests.cs
@@ -1,6 +1,6 @@
 using System;
+using AwesomeAssertions;
 using Candoumbe.Pipelines.Components.NuGet;
-using FluentAssertions;
 using Xunit;
 
 namespace Candoumbe.Pipelines.Tests;

--- a/test/Candoumbe.Pipelines.Tests/IBenchmarkTests.cs
+++ b/test/Candoumbe.Pipelines.Tests/IBenchmarkTests.cs
@@ -1,6 +1,6 @@
 using System.Collections.Generic;
+using AwesomeAssertions;
 using Candoumbe.Pipelines.Components;
-using FluentAssertions;
 using Fallout.Common.IO;
 using Fallout.Common.ProjectModel;
 using Xunit;

--- a/test/Candoumbe.Pipelines.Tests/ICleanTests.cs
+++ b/test/Candoumbe.Pipelines.Tests/ICleanTests.cs
@@ -1,6 +1,6 @@
 using System.Collections.Generic;
+using AwesomeAssertions;
 using Candoumbe.Pipelines.Components;
-using FluentAssertions;
 using Fallout.Common.IO;
 using Xunit;
 

--- a/test/Candoumbe.Pipelines.Tests/IHaveArtifactsTests.cs
+++ b/test/Candoumbe.Pipelines.Tests/IHaveArtifactsTests.cs
@@ -1,5 +1,5 @@
+using AwesomeAssertions;
 using Candoumbe.Pipelines.Components;
-using FluentAssertions;
 using Fallout.Common.IO;
 using Xunit;
 

--- a/test/Candoumbe.Pipelines.Tests/IHaveChangeLogTests.cs
+++ b/test/Candoumbe.Pipelines.Tests/IHaveChangeLogTests.cs
@@ -1,5 +1,5 @@
+using AwesomeAssertions;
 using Candoumbe.Pipelines.Components;
-using FluentAssertions;
 using Fallout.Common.IO;
 using Xunit;
 

--- a/test/Candoumbe.Pipelines.Tests/IHaveCoverageTests.cs
+++ b/test/Candoumbe.Pipelines.Tests/IHaveCoverageTests.cs
@@ -1,5 +1,5 @@
+using AwesomeAssertions;
 using Candoumbe.Pipelines.Components;
-using FluentAssertions;
 using Fallout.Common.IO;
 using Xunit;
 

--- a/test/Candoumbe.Pipelines.Tests/IHaveOutputDirectoryTests.cs
+++ b/test/Candoumbe.Pipelines.Tests/IHaveOutputDirectoryTests.cs
@@ -1,6 +1,6 @@
+using AwesomeAssertions;
 using Candoumbe.Pipelines.Components;
 using Fallout.Common.IO;
-using FluentAssertions;
 using Xunit;
 
 namespace Candoumbe.Pipelines.Tests;

--- a/test/Candoumbe.Pipelines.Tests/IHaveReportTests.cs
+++ b/test/Candoumbe.Pipelines.Tests/IHaveReportTests.cs
@@ -1,5 +1,5 @@
+using AwesomeAssertions;
 using Candoumbe.Pipelines.Components;
-using FluentAssertions;
 using Fallout.Common.IO;
 using Xunit;
 

--- a/test/Candoumbe.Pipelines.Tests/IHaveSourceDirectoryTests.cs
+++ b/test/Candoumbe.Pipelines.Tests/IHaveSourceDirectoryTests.cs
@@ -1,5 +1,5 @@
+using AwesomeAssertions;
 using Candoumbe.Pipelines.Components;
-using FluentAssertions;
 using Fallout.Common.IO;
 using Xunit;
 

--- a/test/Candoumbe.Pipelines.Tests/IHaveTestDirectoryTests.cs
+++ b/test/Candoumbe.Pipelines.Tests/IHaveTestDirectoryTests.cs
@@ -1,5 +1,5 @@
+using AwesomeAssertions;
 using Candoumbe.Pipelines.Components;
-using FluentAssertions;
 using Fallout.Common.IO;
 using Xunit;
 

--- a/test/Candoumbe.Pipelines.Tests/IHaveTestsTests.cs
+++ b/test/Candoumbe.Pipelines.Tests/IHaveTestsTests.cs
@@ -1,5 +1,5 @@
+using AwesomeAssertions;
 using Candoumbe.Pipelines.Components;
-using FluentAssertions;
 using Fallout.Common.IO;
 using Xunit;
 

--- a/test/Candoumbe.Pipelines.Tests/IIntegrationTestTests.cs
+++ b/test/Candoumbe.Pipelines.Tests/IIntegrationTestTests.cs
@@ -1,6 +1,6 @@
 using System.Collections.Generic;
+using AwesomeAssertions;
 using Candoumbe.Pipelines.Components;
-using FluentAssertions;
 using Fallout.Common.IO;
 using Fallout.Common.ProjectModel;
 using Xunit;

--- a/test/Candoumbe.Pipelines.Tests/IMutationTestTests.cs
+++ b/test/Candoumbe.Pipelines.Tests/IMutationTestTests.cs
@@ -1,6 +1,6 @@
 using System.Collections.Generic;
+using AwesomeAssertions;
 using Candoumbe.Pipelines.Components;
-using FluentAssertions;
 using Fallout.Common.IO;
 using Xunit;
 

--- a/test/Candoumbe.Pipelines.Tests/IPackTests.cs
+++ b/test/Candoumbe.Pipelines.Tests/IPackTests.cs
@@ -1,5 +1,5 @@
+using AwesomeAssertions;
 using Candoumbe.Pipelines.Components;
-using FluentAssertions;
 using Fallout.Common.IO;
 using Xunit;
 

--- a/test/Candoumbe.Pipelines.Tests/IReportIntegrationTestCoverageTests.cs
+++ b/test/Candoumbe.Pipelines.Tests/IReportIntegrationTestCoverageTests.cs
@@ -1,5 +1,5 @@
+using AwesomeAssertions;
 using Candoumbe.Pipelines.Components;
-using FluentAssertions;
 using Fallout.Common.IO;
 using Xunit;
 

--- a/test/Candoumbe.Pipelines.Tests/IReportUnitTestCoverageTests.cs
+++ b/test/Candoumbe.Pipelines.Tests/IReportUnitTestCoverageTests.cs
@@ -1,5 +1,5 @@
+using AwesomeAssertions;
 using Candoumbe.Pipelines.Components;
-using FluentAssertions;
 using Fallout.Common.IO;
 using Xunit;
 

--- a/test/Candoumbe.Pipelines.Tests/IUnitTestTests.cs
+++ b/test/Candoumbe.Pipelines.Tests/IUnitTestTests.cs
@@ -1,6 +1,6 @@
 using System.Collections.Generic;
+using AwesomeAssertions;
 using Candoumbe.Pipelines.Components;
-using FluentAssertions;
 using Fallout.Common.IO;
 using Fallout.Common.ProjectModel;
 using Xunit;

--- a/test/Candoumbe.Pipelines.Tests/NugetPushConfigurationTests.cs
+++ b/test/Candoumbe.Pipelines.Tests/NugetPushConfigurationTests.cs
@@ -1,6 +1,6 @@
 using System;
+using AwesomeAssertions;
 using Candoumbe.Pipelines.Components.NuGet;
-using FluentAssertions;
 using Xunit;
 
 namespace Candoumbe.Pipelines.Tests;

--- a/test/Candoumbe.Pipelines.Tests/PathHierarchyTests.cs
+++ b/test/Candoumbe.Pipelines.Tests/PathHierarchyTests.cs
@@ -1,5 +1,5 @@
+using AwesomeAssertions;
 using Candoumbe.Pipelines.Components;
-using FluentAssertions;
 using Fallout.Common.IO;
 using Xunit;
 

--- a/test/Candoumbe.Pipelines.Tests/PushDockerImageConfigurationTests.cs
+++ b/test/Candoumbe.Pipelines.Tests/PushDockerImageConfigurationTests.cs
@@ -1,6 +1,6 @@
 using System;
+using AwesomeAssertions;
 using Candoumbe.Pipelines.Components.Docker;
-using FluentAssertions;
 using Xunit;
 
 namespace Candoumbe.Pipelines.Tests;

--- a/test/Candoumbe.Pipelines.Tests/WorkflowDefaultImplementationsTests.cs
+++ b/test/Candoumbe.Pipelines.Tests/WorkflowDefaultImplementationsTests.cs
@@ -1,9 +1,9 @@
 using System;
 using System.Linq;
 using System.Reflection;
+using AwesomeAssertions;
 using Candoumbe.Pipelines.Components;
 using Candoumbe.Pipelines.Components.Workflows;
-using FluentAssertions;
 using Xunit;
 
 namespace Candoumbe.Pipelines.Tests;


### PR DESCRIPTION
Update the testing framework to use `AwesomeAssertions` instead of `FluentAssertions`, ensuring consistency across the project. Adjust all relevant references and imports accordingly.